### PR TITLE
Refactor algorithm selection logic

### DIFF
--- a/docs/src/dev_interface.md
+++ b/docs/src/dev_interface.md
@@ -1,0 +1,13 @@
+```@meta
+CurrentModule = MatrixAlgebraKit
+CollapsedDocStrings = true
+```
+
+# Developer Interface
+
+MatrixAlgebraKit.jl provides a developer interface for specifying custom algorithm backends and selecting default algorithms.
+
+```@docs; canonical=false
+MatrixAlgebraKit.default_algorithm
+MatrixAlgebraKit.select_algorithm
+```

--- a/src/MatrixAlgebraKit.jl
+++ b/src/MatrixAlgebraKit.jl
@@ -31,7 +31,7 @@ export LAPACK_HouseholderQR, LAPACK_HouseholderLQ,
 export truncrank, trunctol, truncabove, TruncationKeepSorted, TruncationKeepFiltered
 
 VERSION >= v"1.11.0-DEV.469" &&
-    eval(Meta.parse("public default_truncation, select_algorithm"))
+    eval(Meta.parse("public default_algorithm, select_algorithm"))
 
 include("common/defaults.jl")
 include("common/initialization.jl")

--- a/src/MatrixAlgebraKit.jl
+++ b/src/MatrixAlgebraKit.jl
@@ -30,6 +30,8 @@ export LAPACK_HouseholderQR, LAPACK_HouseholderLQ,
        LAPACK_DivideAndConquer, LAPACK_Jacobi
 export truncrank, trunctol, truncabove, TruncationKeepSorted, TruncationKeepFiltered
 
+public default_truncation, select_algorithm
+
 include("common/defaults.jl")
 include("common/initialization.jl")
 include("common/pullbacks.jl")

--- a/src/MatrixAlgebraKit.jl
+++ b/src/MatrixAlgebraKit.jl
@@ -30,7 +30,8 @@ export LAPACK_HouseholderQR, LAPACK_HouseholderLQ,
        LAPACK_DivideAndConquer, LAPACK_Jacobi
 export truncrank, trunctol, truncabove, TruncationKeepSorted, TruncationKeepFiltered
 
-public default_truncation, select_algorithm
+VERSION >= v"1.11.0-DEV.469" &&
+    eval(Meta.parse("public default_truncation, select_algorithm"))
 
 include("common/defaults.jl")
 include("common/initialization.jl")

--- a/src/MatrixAlgebraKit.jl
+++ b/src/MatrixAlgebraKit.jl
@@ -31,7 +31,7 @@ export LAPACK_HouseholderQR, LAPACK_HouseholderLQ,
 export truncrank, trunctol, truncabove, TruncationKeepSorted, TruncationKeepFiltered
 
 VERSION >= v"1.11.0-DEV.469" &&
-    eval(Meta.parse("public default_algorithm, select_algorithm"))
+    eval(Expr(:public, :default_algorithm, :select_algorithm))
 
 include("common/defaults.jl")
 include("common/initialization.jl")

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -61,6 +61,27 @@ implementing the function `f` on inputs of type `A`.
 """
 function select_algorithm end
 
+function select_algorithm(f, A; alg=nothing, kwargs...)
+    return _select_algorithm(f, A, alg; kwargs...)
+end
+
+function _select_algorithm(f, A, alg::Nothing; kwargs...)
+    return default_algorithm(f, A; kwargs...)
+end
+function _select_algorithm(f, A, alg::AbstractAlgorithm; kwargs...)
+    isempty(kwargs) || throw(ArgumentError("Additional keyword arguments are not allowed when an algorithm is specified."))
+    return alg
+end
+function _select_algorithm(f, A, alg::Symbol; kwargs...)
+    return _select_algorithm(f, A, Algorithm{alg}; kwargs...)
+end
+function _select_algorithm(f, A, alg::Type; kwargs...)
+    return _select_algorithm(f, A, alg(; kwargs...))
+end
+function _select_algorithm(f, A, alg; kwargs...)
+    return throw(ArgumentError("Unknown alg $alg"))
+end
+
 @doc """
     copy_input(f, A)
 

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -64,7 +64,7 @@ In general, if an algorithm is specified explicitly through the `alg` keyword ar
 that algorithm will be used instead of selecting it automatically. However, that
 behavior may be modified for factorization functions and/or matrix types.
 
-In general, if the algorithm is not specified, a default algorithm specified by
+When the `alg` keyword argument is not provided, a default algorithm specified by
 [`default_algorithm`](@ref) will be used.
 """
 function select_algorithm end

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -56,8 +56,16 @@ end
 @doc """
     select_algorithm(f, A; kwargs...)
 
-Given some keyword arguments and an input `A`, decide on an algrithm to use for
+Given some keyword arguments and an input `A`, decide on an algorithm to use for
 implementing the function `f` on inputs of type `A`.
+
+In general, if an algorithm is specified explicitly through the `alg` keyword argument
+(either as an algorithm type, an algorithm name as a Symbol, or as an algorithm object),
+that algorithm will be used instead of selecting it automatically. However, that
+behavior may be modified for factorization functions and/or matrix types.
+
+In general, if the algorithm is not specified, a default algorithm specified by
+[`default_algorithm`](@ref) will be used.
 """
 function select_algorithm end
 
@@ -81,6 +89,15 @@ end
 function _select_algorithm(f, A, alg; kwargs...)
     return throw(ArgumentError("Unknown alg $alg"))
 end
+
+@doc """
+    default_algorithm(f, A; kwargs...)
+
+Select the default algorithm for a given factorization function `f` and input `A`.
+In general, this is called by [`select_algorithm`](@ref) if no algorithm is specified
+explicitly.
+"""
+function default_algorithm end
 
 @doc """
     copy_input(f, A)

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -59,7 +59,7 @@ end
 Decide on an algorithm to use for implementing the function `f` on inputs of type `A`.
 
 If `alg` is `nothing` (the default value), an algorithm will be selected automatically
-with [`MatrixAlgebra.default_algorithm`](@ref) and the keyword arguments will be passed
+with [`MatrixAlgebraKit.default_algorithm`](@ref) and the keyword arguments will be passed
 to the algorithm constructor.
 
 If `alg` is a `NamedTuple`, an algorithm will be selected automatically

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -72,17 +72,20 @@ can't be passed to `MatrixAlgebraKit.select_algorithm`.
 """
 function select_algorithm end
 
-Base.@constprop :aggressive function select_algorithm(f::F, A, alg::Alg=nothing; kwargs...) where {F,Alg}
+Base.@constprop :aggressive function select_algorithm(f::F, A, alg::Alg=nothing;
+                                                      kwargs...) where {F,Alg}
     return _select_algorithm(f, A, alg; kwargs...)
 end
 
 function _select_algorithm(f::F, A, alg::Nothing; kwargs...) where {F}
     return default_algorithm(f, A; kwargs...)
 end
-Base.@constprop :aggressive function _select_algorithm(f::F, A, alg::Symbol; kwargs...) where {F}
+Base.@constprop :aggressive function _select_algorithm(f::F, A, alg::Symbol;
+                                                       kwargs...) where {F}
     return Algorithm{alg}(; kwargs...)
 end
-Base.@constprop :aggressive function _select_algorithm(f::F, A, ::Type{Alg}; kwargs...) where {F,Alg}
+Base.@constprop :aggressive function _select_algorithm(f::F, A, ::Type{Alg};
+                                                       kwargs...) where {F,Alg}
     return Alg(; kwargs...)
 end
 function _select_algorithm(f::F, A, alg::NamedTuple; kwargs...) where {F}
@@ -174,7 +177,8 @@ macro functiondef(f)
 
     return esc(quote
                    # out of place to inplace
-                   Base.@constprop :aggressive $f(A; kwargs...) = $f!(copy_input($f, A); kwargs...)
+                   Base.@constprop :aggressive $f(A; kwargs...) = $f!(copy_input($f, A);
+                                                                      kwargs...)
                    $f(A, alg::AbstractAlgorithm) = $f!(copy_input($f, A), alg)
 
                    # fill in arguments

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -77,7 +77,8 @@ function _select_algorithm(f, A, alg::Nothing; kwargs...)
     return default_algorithm(f, A; kwargs...)
 end
 function _select_algorithm(f, A, alg::AbstractAlgorithm; kwargs...)
-    isempty(kwargs) || throw(ArgumentError("Additional keyword arguments are not allowed when an algorithm is specified."))
+    isempty(kwargs) ||
+        throw(ArgumentError("Additional keyword arguments are not allowed when an algorithm is specified."))
     return alg
 end
 function _select_algorithm(f, A, alg::Symbol; kwargs...)
@@ -87,7 +88,8 @@ function _select_algorithm(f, A, alg::Type; kwargs...)
     return _select_algorithm(f, A, alg(; kwargs...))
 end
 function _select_algorithm(f, A::AbstractMatrix, alg::NamedTuple; kwargs...)
-    isempty(kwargs) || throw(ArgumentError("Additional keyword arguments are not allowed when algorithm parameters are specified."))
+    isempty(kwargs) ||
+        throw(ArgumentError("Additional keyword arguments are not allowed when algorithm parameters are specified."))
     return select_algorithm(f, A; alg...)
 end
 function _select_algorithm(f, A, alg; kwargs...)

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -72,20 +72,17 @@ can't be passed to `MatrixAlgebraKit.select_algorithm`.
 """
 function select_algorithm end
 
-Base.@constprop :aggressive function select_algorithm(f::F, A, alg::Alg=nothing;
-                                                      kwargs...) where {F,Alg}
+function select_algorithm(f::F, A, alg::Alg=nothing; kwargs...) where {F,Alg}
     return _select_algorithm(f, A, alg; kwargs...)
 end
 
 function _select_algorithm(f::F, A, alg::Nothing; kwargs...) where {F}
     return default_algorithm(f, A; kwargs...)
 end
-Base.@constprop :aggressive function _select_algorithm(f::F, A, alg::Symbol;
-                                                       kwargs...) where {F}
+function _select_algorithm(f::F, A, alg::Symbol; kwargs...) where {F}
     return Algorithm{alg}(; kwargs...)
 end
-Base.@constprop :aggressive function _select_algorithm(f::F, A, ::Type{Alg};
-                                                       kwargs...) where {F,Alg}
+function _select_algorithm(f::F, A, ::Type{Alg}; kwargs...) where {F,Alg}
     return Alg(; kwargs...)
 end
 function _select_algorithm(f::F, A, alg::NamedTuple; kwargs...) where {F}
@@ -177,15 +174,14 @@ macro functiondef(f)
 
     return esc(quote
                    # out of place to inplace
-                   Base.@constprop :aggressive $f(A; kwargs...) = $f!(copy_input($f, A);
-                                                                      kwargs...)
+                   $f(A; kwargs...) = $f!(copy_input($f, A); kwargs...)
                    $f(A, alg::AbstractAlgorithm) = $f!(copy_input($f, A), alg)
 
                    # fill in arguments
-                   Base.@constprop :aggressive function $f!(A; alg=nothing, kwargs...)
+                   function $f!(A; alg=nothing, kwargs...)
                        return $f!(A, select_algorithm($f!, A, alg; kwargs...))
                    end
-                   Base.@constprop :aggressive function $f!(A, out; alg=nothing, kwargs...)
+                   function $f!(A, out; alg=nothing, kwargs...)
                        return $f!(A, out, select_algorithm($f!, A, alg; kwargs...))
                    end
                    function $f!(A, alg::AbstractAlgorithm)

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -54,7 +54,7 @@ function _show_alg(io::IO, alg::Algorithm)
 end
 
 @doc """
-    select_algorithm(f, A; kwargs...)
+    MatrixAlgebraKit.select_algorithm(f, A; kwargs...)
 
 Given some keyword arguments and an input `A`, decide on an algorithm to use for
 implementing the function `f` on inputs of type `A`.
@@ -82,7 +82,7 @@ function _select_algorithm(f, A, alg::AbstractAlgorithm; kwargs...)
     return alg
 end
 function _select_algorithm(f, A, alg::Symbol; kwargs...)
-    return _select_algorithm(f, A, Algorithm{alg}; kwargs...)
+    return _select_algorithm(f, A, Algorithm{alg}(; kwargs...))
 end
 function _select_algorithm(f, A, alg::Type; kwargs...)
     return _select_algorithm(f, A, alg(; kwargs...))
@@ -97,7 +97,7 @@ function _select_algorithm(f, A, alg; kwargs...)
 end
 
 @doc """
-    default_algorithm(f, A; kwargs...)
+    MatrixAlgebraKit.default_algorithm(f, A; kwargs...)
 
 Select the default algorithm for a given factorization function `f` and input `A`.
 In general, this is called by [`select_algorithm`](@ref) if no algorithm is specified

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -54,21 +54,25 @@ function _show_alg(io::IO, alg::Algorithm)
 end
 
 @doc """
-    MatrixAlgebraKit.select_algorithm(f, A, alg=nothing; kwargs...)
+    MatrixAlgebraKit.select_algorithm(f, A, alg::AbstractAlgorithm)
+    MatrixAlgebraKit.select_algorithm(f, A, alg::Symbol; kwargs...)
+    MatrixAlgebraKit.select_algorithm(f, A, alg::Type; kwargs...)
+    MatrixAlgebraKit.select_algorithm(f, A; kwargs...)
+    MatrixAlgebraKit.select_algorithm(f, A, (; kwargs...))
 
 Decide on an algorithm to use for implementing the function `f` on inputs of type `A`.
 
-If `alg` is `nothing` (the default value), an algorithm will be selected automatically
-with [`MatrixAlgebraKit.default_algorithm`](@ref) and the keyword arguments will be passed
-to the algorithm constructor.
+If `alg` is an `AbstractAlgorithm` instance, it will be returned as-is.
 
-If `alg` is a `NamedTuple`, an algorithm will be selected automatically
-with [`default_algorithm`](@ref) and `alg` will be passed to the algorithm
-as keyword arguments. In that case, keyword arguments can't be passed
-to `MatrixAlgebraKit.select_algorithm`
+If `alg` is a `Symbol` or a `Type` of algorithm, the return value is obtained
+by calling the corresponding algorithm constructor;
+keyword arguments in `kwargs` are passed along  to this constructor.
 
-If `alg` is an `AbstractAlgorithm`, it will be returned as-is. In that case, keyword arguments
-can't be passed to `MatrixAlgebraKit.select_algorithm`.
+If `alg` is not specified (or `nothing`), an algorithm will be selected 
+automatically with [`MatrixAlgebraKit.default_algorithm`](@ref) and 
+the keyword arguments in `kwargs` will be passed to the algorithm constructor.
+Finally, the same behavior is obtained when the keyword arguments are
+passed as the third positional argument in the form of a `NamedTuple`. 
 """
 function select_algorithm end
 

--- a/src/implementations/orthnull.jl
+++ b/src/implementations/orthnull.jl
@@ -89,22 +89,22 @@ function left_orth!(A::AbstractMatrix, VC; trunc=nothing,
         throw(ArgumentError("truncation not supported for left_orth with kind=$kind"))
     end
     if kind == :qr
-        alg_qr′ = _select_algorithm(qr_compact!, A, alg_qr)
+        alg_qr′ = select_algorithm(qr_compact!, A, alg_qr)
         return qr_compact!(A, VC, alg_qr′)
     elseif kind == :polar
         size(A, 1) >= size(A, 2) ||
             throw(ArgumentError("`left_orth!` with `kind = :polar` only possible for `(m, n)` matrix with `m >= n`"))
-        alg_polar′ = _select_algorithm(left_polar!, A, alg_polar)
+        alg_polar′ = select_algorithm(left_polar!, A, alg_polar)
         return left_polar!(A, VC, alg_polar′)
     elseif kind == :svd && isnothing(trunc)
-        alg_svd′ = _select_algorithm(svd_compact!, A, alg_svd)
+        alg_svd′ = select_algorithm(svd_compact!, A, alg_svd)
         V, C = VC
         S = Diagonal(initialize_output(svd_vals!, A, alg_svd′))
         U, S, Vᴴ = svd_compact!(A, (V, S, C), alg_svd′)
         return U, lmul!(S, Vᴴ)
     elseif kind == :svd
-        alg_svd′ = _select_algorithm(svd_compact!, A, alg_svd)
-        alg_svd_trunc = select_algorithm(svd_trunc!, A; trunc, alg=alg_svd′)
+        alg_svd′ = select_algorithm(svd_compact!, A, alg_svd)
+        alg_svd_trunc = select_algorithm(svd_trunc!, A, alg_svd′; trunc)
         V, C = VC
         S = Diagonal(initialize_output(svd_vals!, A, alg_svd_trunc.alg))
         U, S, Vᴴ = svd_trunc!(A, (V, S, C), alg_svd_trunc)
@@ -122,22 +122,22 @@ function right_orth!(A::AbstractMatrix, CVᴴ; trunc=nothing,
         throw(ArgumentError("truncation not supported for right_orth with kind=$kind"))
     end
     if kind == :lq
-        alg_lq′ = _select_algorithm(lq_compact!, A, alg_lq)
+        alg_lq′ = select_algorithm(lq_compact!, A, alg_lq)
         return lq_compact!(A, CVᴴ, alg_lq′)
     elseif kind == :polar
         size(A, 2) >= size(A, 1) ||
             throw(ArgumentError("`right_orth!` with `kind = :polar` only possible for `(m, n)` matrix with `m <= n`"))
-        alg_polar′ = _select_algorithm(right_polar!, A, alg_polar)
+        alg_polar′ = select_algorithm(right_polar!, A, alg_polar)
         return right_polar!(A, CVᴴ, alg_polar′)
     elseif kind == :svd && isnothing(trunc)
-        alg_svd′ = _select_algorithm(svd_compact!, A, alg_svd)
+        alg_svd′ = select_algorithm(svd_compact!, A, alg_svd)
         C, Vᴴ = CVᴴ
         S = Diagonal(initialize_output(svd_vals!, A, alg_svd′))
         U, S, Vᴴ = svd_compact!(A, (C, S, Vᴴ), alg_svd′)
         return rmul!(U, S), Vᴴ
     elseif kind == :svd
-        alg_svd′ = _select_algorithm(svd_compact!, A, alg_svd)
-        alg_svd_trunc = select_algorithm(svd_trunc!, A; trunc, alg=alg_svd′)
+        alg_svd′ = select_algorithm(svd_compact!, A, alg_svd)
+        alg_svd_trunc = select_algorithm(svd_trunc!, A, alg_svd′; trunc)
         C, Vᴴ = CVᴴ
         S = Diagonal(initialize_output(svd_vals!, A, alg_svd_trunc.alg))
         U, S, Vᴴ = svd_trunc!(A, (C, S, Vᴴ), alg_svd_trunc)
@@ -167,15 +167,15 @@ function left_null!(A::AbstractMatrix, N; trunc=nothing,
         throw(ArgumentError("truncation not supported for left_null with kind=$kind"))
     end
     if kind == :qr
-        alg_qr′ = _select_algorithm(qr_null!, A, alg_qr)
+        alg_qr′ = select_algorithm(qr_null!, A, alg_qr)
         return qr_null!(A, N, alg_qr′)
     elseif kind == :svd && isnothing(trunc)
-        alg_svd′ = _select_algorithm(svd_full!, A, alg_svd)
+        alg_svd′ = select_algorithm(svd_full!, A, alg_svd)
         U, _, _ = svd_full!(A, alg_svd′)
         (m, n) = size(A)
         return copy!(N, view(U, 1:m, (n + 1):m))
     elseif kind == :svd
-        alg_svd′ = _select_algorithm(svd_full!, A, alg_svd)
+        alg_svd′ = select_algorithm(svd_full!, A, alg_svd)
         U, S, _ = svd_full!(A, alg_svd′)
         trunc′ = trunc isa TruncationStrategy ? trunc :
                  trunc isa NamedTuple ? null_truncation_strategy(; trunc...) :
@@ -194,15 +194,15 @@ function right_null!(A::AbstractMatrix, Nᴴ; trunc=nothing,
         throw(ArgumentError("truncation not supported for right_null with kind=$kind"))
     end
     if kind == :lq
-        alg_lq′ = _select_algorithm(lq_null!, A, alg_lq)
+        alg_lq′ = select_algorithm(lq_null!, A, alg_lq)
         return lq_null!(A, Nᴴ, alg_lq′)
     elseif kind == :svd && isnothing(trunc)
-        alg_svd′ = _select_algorithm(svd_full!, A, alg_svd)
+        alg_svd′ = select_algorithm(svd_full!, A, alg_svd)
         _, _, Vᴴ = svd_full!(A, alg_svd′)
         (m, n) = size(A)
         return copy!(Nᴴ, view(Vᴴ, (m + 1):n, 1:n))
     elseif kind == :svd
-        alg_svd′ = _select_algorithm(svd_full!, A, alg_svd)
+        alg_svd′ = select_algorithm(svd_full!, A, alg_svd)
         _, S, Vᴴ = svd_full!(A, alg_svd′)
         trunc′ = trunc isa TruncationStrategy ? trunc :
                  trunc isa NamedTuple ? null_truncation_strategy(; trunc...) :

--- a/src/implementations/truncation.jl
+++ b/src/implementations/truncation.jl
@@ -111,8 +111,9 @@ struct TruncationIntersection{T<:Tuple{Vararg{TruncationStrategy}}} <:
        TruncationStrategy
     components::T
 end
-TruncationIntersection(trunc::TruncationStrategy, truncs::TruncationStrategy...) = 
-    TruncationIntersection((trunc, truncs...))
+function TruncationIntersection(trunc::TruncationStrategy, truncs::TruncationStrategy...)
+    return TruncationIntersection((trunc, truncs...))
+end
 
 function Base.:&(trunc1::TruncationStrategy, trunc2::TruncationStrategy)
     return TruncationIntersection((trunc1, trunc2))

--- a/src/implementations/truncation.jl
+++ b/src/implementations/truncation.jl
@@ -32,6 +32,19 @@ Trivial truncation strategy that keeps all values, mostly for testing purposes.
 """
 struct NoTruncation <: TruncationStrategy end
 
+function to_truncationstrategy(trunc::TruncationStrategy)
+    return trunc
+end
+function to_truncationstrategy(trunc::NamedTuple)
+    return TruncationStrategy(; trunc...)
+end
+function to_truncationstrategy(trunc::Nothing)
+    return NoTruncation()
+end
+function to_truncationstrategy(trunc)
+    return throw(ArgumentError("Unknown truncation strategy: $trunc"))
+end
+
 # TODO: how do we deal with sorting/filters that treat zeros differently
 # since these are implicitly discarded by selecting compact/full
 

--- a/src/implementations/truncation.jl
+++ b/src/implementations/truncation.jl
@@ -32,17 +32,16 @@ Trivial truncation strategy that keeps all values, mostly for testing purposes.
 """
 struct NoTruncation <: TruncationStrategy end
 
-function select_truncation(trunc::TruncationStrategy)
-    return trunc
-end
-function select_truncation(trunc::NamedTuple)
-    return TruncationStrategy(; trunc...)
-end
-function select_truncation(trunc::Nothing)
-    return NoTruncation()
-end
 function select_truncation(trunc)
-    return throw(ArgumentError("Unknown truncation strategy: $trunc"))
+    if isnothing(trunc)
+        return NoTruncation()
+    elseif trunc isa NamedTuple
+        return TruncationStrategy(; trunc...)
+    elseif trunc isa TruncationStrategy
+        return trunc
+    else
+        return throw(ArgumentError("Unknown truncation strategy: $trunc"))
+    end
 end
 
 # TODO: how do we deal with sorting/filters that treat zeros differently

--- a/src/implementations/truncation.jl
+++ b/src/implementations/truncation.jl
@@ -32,16 +32,16 @@ Trivial truncation strategy that keeps all values, mostly for testing purposes.
 """
 struct NoTruncation <: TruncationStrategy end
 
-function to_truncationstrategy(trunc::TruncationStrategy)
+function select_truncation(trunc::TruncationStrategy)
     return trunc
 end
-function to_truncationstrategy(trunc::NamedTuple)
+function select_truncation(trunc::NamedTuple)
     return TruncationStrategy(; trunc...)
 end
-function to_truncationstrategy(trunc::Nothing)
+function select_truncation(trunc::Nothing)
     return NoTruncation()
 end
-function to_truncationstrategy(trunc)
+function select_truncation(trunc)
     return throw(ArgumentError("Unknown truncation strategy: $trunc"))
 end
 

--- a/src/interface/eig.jl
+++ b/src/interface/eig.jl
@@ -104,7 +104,7 @@ function select_algorithm(::typeof(eig_trunc), A; kwargs...)
 end
 function select_algorithm(::typeof(eig_trunc!), A; trunc=nothing, kwargs...)
     alg_eig = select_algorithm(eig_full!, A; kwargs...)
-    return TruncatedAlgorithm(alg_eig, to_truncationstrategy(trunc))
+    return TruncatedAlgorithm(alg_eig, select_truncation(trunc))
 end
 
 # Default to LAPACK 

--- a/src/interface/eig.jl
+++ b/src/interface/eig.jl
@@ -99,11 +99,11 @@ for f in (:eig_full, :eig_vals)
     end
 end
 
-function select_algorithm(::typeof(eig_trunc), A; kwargs...)
-    return select_algorithm(eig_trunc!, A; kwargs...)
+function select_algorithm(::typeof(eig_trunc), A, alg; kwargs...)
+    return select_algorithm(eig_trunc!, A, alg; kwargs...)
 end
-function select_algorithm(::typeof(eig_trunc!), A; trunc=nothing, kwargs...)
-    alg_eig = select_algorithm(eig_full!, A; kwargs...)
+function select_algorithm(::typeof(eig_trunc!), A, alg; trunc=nothing, kwargs...)
+    alg_eig = select_algorithm(eig_full!, A, alg; kwargs...)
     return TruncatedAlgorithm(alg_eig, select_truncation(trunc))
 end
 

--- a/src/interface/eigh.jl
+++ b/src/interface/eigh.jl
@@ -98,11 +98,11 @@ for f in (:eigh_full, :eigh_vals)
     end
 end
 
-function select_algorithm(::typeof(eigh_trunc), A; kwargs...)
-    return select_algorithm(eigh_trunc!, A; kwargs...)
+function select_algorithm(::typeof(eigh_trunc), A, alg; kwargs...)
+    return select_algorithm(eigh_trunc!, A, alg; kwargs...)
 end
-function select_algorithm(::typeof(eigh_trunc!), A; trunc=nothing, kwargs...)
-    alg_eigh = select_algorithm(eigh_full!, A; kwargs...)
+function select_algorithm(::typeof(eigh_trunc!), A, alg; trunc=nothing, kwargs...)
+    alg_eigh = select_algorithm(eigh_full!, A, alg; kwargs...)
     return TruncatedAlgorithm(alg_eigh, select_truncation(trunc))
 end
 

--- a/src/interface/eigh.jl
+++ b/src/interface/eigh.jl
@@ -103,7 +103,7 @@ function select_algorithm(::typeof(eigh_trunc), A; kwargs...)
 end
 function select_algorithm(::typeof(eigh_trunc!), A; trunc=nothing, kwargs...)
     alg_eigh = select_algorithm(eigh_full!, A; kwargs...)
-    return TruncatedAlgorithm(alg_eigh, to_truncationstrategy(trunc))
+    return TruncatedAlgorithm(alg_eigh, select_truncation(trunc))
 end
 
 # Default to LAPACK 

--- a/src/interface/eigh.jl
+++ b/src/interface/eigh.jl
@@ -89,18 +89,11 @@ See also [`eigh_full(!)`](@ref eigh_full) and [`eigh_trunc(!)`](@ref eigh_trunc)
 for f in (:eigh_full, :eigh_vals)
     f! = Symbol(f, :!)
     @eval begin
-        function select_algorithm(::typeof($f), A; kwargs...)
-            return select_algorithm($f!, A; kwargs...)
+        function default_algorithm(::typeof($f), A; kwargs...)
+            return default_algorithm($f!, A; kwargs...)
         end
-        function select_algorithm(::typeof($f!), A; alg=nothing, kwargs...)
-            if alg isa AbstractAlgorithm
-                return alg
-            elseif alg isa Symbol
-                return Algorithm{alg}(; kwargs...)
-            else
-                isnothing(alg) || throw(ArgumentError("Unknown alg $alg"))
-                return default_eigh_algorithm(A; kwargs...)
-            end
+        function default_algorithm(::typeof($f!), A; kwargs...)
+            return default_eig_algorithm(A; kwargs...)
         end
     end
 end
@@ -108,13 +101,9 @@ end
 function select_algorithm(::typeof(eigh_trunc), A; kwargs...)
     return select_algorithm(eigh_trunc!, A; kwargs...)
 end
-function select_algorithm(::typeof(eigh_trunc!), A; alg=nothing, trunc=nothing, kwargs...)
-    alg_eigh = select_algorithm(eigh_full!, A; alg, kwargs...)
-    alg_trunc = trunc isa TruncationStrategy ? trunc :
-                trunc isa NamedTuple ? TruncationStrategy(; trunc...) :
-                isnothing(trunc) ? NoTruncation() :
-                throw(ArgumentError("Unknown truncation strategy: $trunc"))
-    return TruncatedAlgorithm(alg_eigh, alg_trunc)
+function select_algorithm(::typeof(eigh_trunc!), A; trunc=nothing, kwargs...)
+    alg_eigh = select_algorithm(eigh_full!, A; kwargs...)
+    return TruncatedAlgorithm(alg_eigh, to_truncationstrategy(trunc))
 end
 
 # Default to LAPACK 

--- a/src/interface/eigh.jl
+++ b/src/interface/eigh.jl
@@ -93,7 +93,7 @@ for f in (:eigh_full, :eigh_vals)
             return default_algorithm($f!, A; kwargs...)
         end
         function default_algorithm(::typeof($f!), A; kwargs...)
-            return default_eig_algorithm(A; kwargs...)
+            return default_eigh_algorithm(A; kwargs...)
         end
     end
 end

--- a/src/interface/lq.jl
+++ b/src/interface/lq.jl
@@ -71,18 +71,11 @@ See also [`qr_full(!)`](@ref lq_full) and [`qr_compact(!)`](@ref lq_compact).
 for f in (:lq_full, :lq_compact, :lq_null)
     f! = Symbol(f, :!)
     @eval begin
-        function select_algorithm(::typeof($f), A; kwargs...)
-            return select_algorithm($f!, A; kwargs...)
+        function default_algorithm(::typeof($f), A; kwargs...)
+            return default_algorithm($f!, A; kwargs...)
         end
-        function select_algorithm(::typeof($f!), A; alg=nothing, kwargs...)
-            if alg isa AbstractAlgorithm
-                return alg
-            elseif alg isa Symbol
-                return Algorithm{alg}(; kwargs...)
-            else
-                isnothing(alg) || throw(ArgumentError("Unknown alg $alg"))
-                return default_lq_algorithm(A; kwargs...)
-            end
+        function default_algorithm(::typeof($f!), A; kwargs...)
+            return default_lq_algorithm(A; kwargs...)
         end
     end
 end

--- a/src/interface/polar.jl
+++ b/src/interface/polar.jl
@@ -63,18 +63,11 @@ end
 for f in (:left_polar, :right_polar)
     f! = Symbol(f, :!)
     @eval begin
-        function select_algorithm(::typeof($f), A; kwargs...)
-            return select_algorithm($f!, A; kwargs...)
+        function default_algorithm(::typeof($f), A; kwargs...)
+            return default_algorithm($f!, A; kwargs...)
         end
-        function select_algorithm(::typeof($f!), A; alg=nothing, kwargs...)
-            if alg isa AbstractAlgorithm
-                return alg
-            elseif alg isa Symbol
-                return Algorithm{alg}(; kwargs...)
-            else
-                isnothing(alg) || throw(ArgumentError("Unknown alg $alg"))
-                return default_polar_algorithm(A; kwargs...)
-            end
+        function default_algorithm(::typeof($f!), A; kwargs...)
+            return default_polar_algorithm(A; kwargs...)
         end
     end
 end

--- a/src/interface/qr.jl
+++ b/src/interface/qr.jl
@@ -71,18 +71,11 @@ See also [`lq_full(!)`](@ref lq_full) and [`lq_compact(!)`](@ref lq_compact).
 for f in (:qr_full, :qr_compact, :qr_null)
     f! = Symbol(f, :!)
     @eval begin
-        function select_algorithm(::typeof($f), A; kwargs...)
-            return select_algorithm($f!, A; kwargs...)
+        function default_algorithm(::typeof($f), A; kwargs...)
+            return default_algorithm($f!, A; kwargs...)
         end
-        function select_algorithm(::typeof($f!), A; alg=nothing, kwargs...)
-            if alg isa AbstractAlgorithm
-                return alg
-            elseif alg isa Symbol
-                return Algorithm{alg}(; kwargs...)
-            else
-                isnothing(alg) || throw(ArgumentError("Unknown alg $alg"))
-                return default_qr_algorithm(A; kwargs...)
-            end
+        function default_algorithm(::typeof($f!), A; kwargs...)
+            return default_qr_algorithm(A; kwargs...)
         end
     end
 end

--- a/src/interface/schur.jl
+++ b/src/interface/schur.jl
@@ -54,18 +54,11 @@ See also [`eig_full(!)`](@ref eig_full) and [`eig_trunc(!)`](@ref eig_trunc).
 for f in (:schur_full, :schur_vals)
     f! = Symbol(f, :!)
     @eval begin
-        function select_algorithm(::typeof($f), A; kwargs...)
-            return select_algorithm($f!, A; kwargs...)
+        function default_algorithm(::typeof($f), A; kwargs...)
+            return default_algorithm($f!, A; kwargs...)
         end
-        function select_algorithm(::typeof($f!), A; alg=nothing, kwargs...)
-            if alg isa AbstractAlgorithm
-                return alg
-            elseif alg isa Symbol
-                return Algorithm{alg}(; kwargs...)
-            else
-                isnothing(alg) || throw(ArgumentError("Unknown alg $alg"))
-                return default_eig_algorithm(A; kwargs...)
-            end
+        function default_algorithm(::typeof($f!), A; kwargs...)
+            return default_eig_algorithm(A; kwargs...)
         end
     end
 end

--- a/src/interface/svd.jl
+++ b/src/interface/svd.jl
@@ -102,11 +102,11 @@ for f in (:svd_full, :svd_compact, :svd_vals)
     end
 end
 
-function select_algorithm(::typeof(svd_trunc), A; kwargs...)
-    return select_algorithm(svd_trunc!, A; kwargs...)
+function select_algorithm(::typeof(svd_trunc), A, alg; kwargs...)
+    return select_algorithm(svd_trunc!, A, alg; kwargs...)
 end
-function select_algorithm(::typeof(svd_trunc!), A; trunc=nothing, kwargs...)
-    alg_svd = select_algorithm(svd_compact!, A; kwargs...)
+function select_algorithm(::typeof(svd_trunc!), A, alg; trunc=nothing, kwargs...)
+    alg_svd = select_algorithm(svd_compact!, A, alg; kwargs...)
     return TruncatedAlgorithm(alg_svd, select_truncation(trunc))
 end
 

--- a/src/interface/svd.jl
+++ b/src/interface/svd.jl
@@ -107,7 +107,7 @@ function select_algorithm(::typeof(svd_trunc), A; kwargs...)
 end
 function select_algorithm(::typeof(svd_trunc!), A; trunc=nothing, kwargs...)
     alg_svd = select_algorithm(svd_compact!, A; kwargs...)
-    return TruncatedAlgorithm(alg_svd, to_truncationstrategy(trunc))
+    return TruncatedAlgorithm(alg_svd, select_truncation(trunc))
 end
 
 # Default to LAPACK SDD for `StridedMatrix{<:BlasFloat}`

--- a/test/algorithms.jl
+++ b/test/algorithms.jl
@@ -1,0 +1,62 @@
+using MatrixAlgebraKit
+using Test
+using TestExtras
+using MatrixAlgebraKit: LAPACK_SVDAlgorithm, NoTruncation, PolarViaSVD, TruncatedAlgorithm,
+                        default_algorithm, select_algorithm
+
+@testset "default_algorithm" begin
+    A = randn(3, 3)
+    for f in (svd_compact!, svd_compact, svd_full!, svd_full)
+        @test @constinferred(default_algorithm(f, A)) === LAPACK_DivideAndConquer()
+    end
+    for f in (eig_full!, eig_full, eig_vals!, eig_vals)
+        @test @constinferred(default_algorithm(f, A)) === LAPACK_Expert()
+    end
+    for f in (eigh_full!, eigh_full, eigh_vals!, eigh_vals)
+        @test @constinferred(default_algorithm(f, A)) ===
+              LAPACK_MultipleRelativelyRobustRepresentations()
+    end
+    for f in (lq_full!, lq_full, lq_compact!, lq_compact, lq_null!, lq_null)
+        @test @constinferred(default_algorithm(f, A)) == LAPACK_HouseholderLQ()
+    end
+    for f in (left_polar!, left_polar, right_polar!, right_polar)
+        @test @constinferred(default_algorithm(f, A)) ==
+              PolarViaSVD(LAPACK_DivideAndConquer())
+    end
+    for f in (qr_full!, qr_full, qr_compact!, qr_compact, qr_null!, qr_null)
+        @test @constinferred(default_algorithm(f, A)) == LAPACK_HouseholderQR()
+    end
+    for f in (schur_full!, schur_full, schur_vals!, schur_vals)
+        @test @constinferred(default_algorithm(f, A)) === LAPACK_Expert()
+    end
+
+    @test @constinferred(default_algorithm(qr_compact!, A; blocksize=2)) ===
+          LAPACK_HouseholderQR(; blocksize=2)
+end
+
+@testset "select_algorithm" begin
+    A = randn(3, 3)
+    for f in (svd_trunc!, svd_trunc)
+        @test @constinferred(select_algorithm(f, A)) ===
+              TruncatedAlgorithm(LAPACK_DivideAndConquer(), NoTruncation())
+    end
+    for f in (eig_trunc!, eig_trunc)
+        @test @constinferred(select_algorithm(f, A)) ===
+              TruncatedAlgorithm(LAPACK_Expert(), NoTruncation())
+    end
+    for f in (eigh_trunc!, eigh_trunc)
+        @test @constinferred(select_algorithm(f, A)) ===
+              TruncatedAlgorithm(LAPACK_MultipleRelativelyRobustRepresentations(),
+                                 NoTruncation())
+    end
+
+    @test @constinferred(select_algorithm(svd_compact!, A)) === LAPACK_DivideAndConquer()
+    @test @constinferred(select_algorithm(svd_compact!, A, nothing)) ===
+          LAPACK_DivideAndConquer()
+    @test @constinferred(select_algorithm(svd_compact!, A, :LAPACK_QRIteration)) ===
+          LAPACK_QRIteration()
+    @test @constinferred(select_algorithm(svd_compact!, A, LAPACK_QRIteration)) ===
+          LAPACK_QRIteration()
+    @test @constinferred(select_algorithm(svd_compact!, A, LAPACK_QRIteration())) ===
+          LAPACK_QRIteration()
+end

--- a/test/algorithms.jl
+++ b/test/algorithms.jl
@@ -53,10 +53,8 @@ end
     @test @constinferred(select_algorithm(svd_compact!, A)) === LAPACK_DivideAndConquer()
     @test @constinferred(select_algorithm(svd_compact!, A, nothing)) ===
           LAPACK_DivideAndConquer()
-    @test @constinferred(select_algorithm(svd_compact!, A, :LAPACK_QRIteration)) ===
-          LAPACK_QRIteration()
-    @test @constinferred(select_algorithm(svd_compact!, A, LAPACK_QRIteration)) ===
-          LAPACK_QRIteration()
-    @test @constinferred(select_algorithm(svd_compact!, A, LAPACK_QRIteration())) ===
-          LAPACK_QRIteration()
+    for alg in (:LAPACK_QRIteration, LAPACK_QRIteration, LAPACK_QRIteration())
+        @test @constinferred(select_algorithm(svd_compact!, A, $alg)) ===
+              LAPACK_QRIteration()
+    end
 end

--- a/test/eig.jl
+++ b/test/eig.jl
@@ -8,21 +8,35 @@ using MatrixAlgebraKit: diagview
 @testset "eig_full! for T = $T" for T in (Float32, Float64, ComplexF32, ComplexF64)
     rng = StableRNG(123)
     m = 54
-    for alg in (LAPACK_Simple(), LAPACK_Expert())
+    for alg in
+        (LAPACK_Simple(), LAPACK_Expert(), LAPACK_Simple, LAPACK_Expert, :LAPACK_Simple,
+         :LAPACK_Expert)
         A = randn(rng, T, m, m)
         Tc = complex(T)
 
-        D, V = @constinferred eig_full(A; alg)
+        alg′ = if (alg isa Type) || (alg isa Symbol)
+            # These cases aren't inferable right now.
+            MatrixAlgebraKit.select_algorithm(eig_full!, A; alg)
+        else
+            @constinferred MatrixAlgebraKit.select_algorithm(eig_full!, A; alg)
+        end
+
+        D, V = if (alg isa Type) || (alg isa Symbol)
+            # These cases aren't inferable right now.
+            eig_full(A; alg)
+        else
+            @constinferred eig_full(A; alg)
+        end
         @test eltype(D) == eltype(V) == Tc
         @test A * V ≈ V * D
 
         Ac = similar(A)
-        D2, V2 = @constinferred eig_full!(copy!(Ac, A), (D, V), alg)
+        D2, V2 = @constinferred eig_full!(copy!(Ac, A), (D, V), alg′)
         @test D2 === D
         @test V2 === V
         @test A * V ≈ V * D
 
-        Dc = @constinferred eig_vals(A, alg)
+        Dc = @constinferred eig_vals(A, alg′)
         @test eltype(Dc) == Tc
         @test D ≈ Diagonal(Dc)
     end

--- a/test/eig.jl
+++ b/test/eig.jl
@@ -8,15 +8,15 @@ using MatrixAlgebraKit: diagview
 @testset "eig_full! for T = $T" for T in (Float32, Float64, ComplexF32, ComplexF64)
     rng = StableRNG(123)
     m = 54
-    for alg in (LAPACK_Simple(), LAPACK_Expert())
+    for alg in (LAPACK_Simple(), LAPACK_Expert(), :LAPACK_Simple, LAPACK_Simple)
         A = randn(rng, T, m, m)
         Tc = complex(T)
 
-        D, V = @constinferred eig_full(A; alg)
+        D, V = @constinferred eig_full(A; alg=($alg))
         @test eltype(D) == eltype(V) == Tc
         @test A * V ≈ V * D
 
-        alg′ = @constinferred MatrixAlgebraKit.select_algorithm(eig_full!, A, alg)
+        alg′ = @constinferred MatrixAlgebraKit.select_algorithm(eig_full!, A, $alg)
 
         Ac = similar(A)
         D2, V2 = @constinferred eig_full!(copy!(Ac, A), (D, V), alg′)
@@ -28,21 +28,6 @@ using MatrixAlgebraKit: diagview
         @test eltype(Dc) == Tc
         @test D ≈ Diagonal(Dc)
     end
-
-    # Test other alg inputs.
-    A = randn(rng, T, m, m)
-    Tc = complex(T)
-    D, V = @constinferred eig_full(A; alg=:LAPACK_Simple)
-    @test eltype(D) == eltype(V) == Tc
-    @test A * V ≈ V * D
-
-    A = randn(rng, T, m, m)
-    Tc = complex(T)
-    ## Inference is broken for this case for some reason.
-    ## D, V = @constinferred eig_full(A; alg=LAPACK_Simple)
-    D, V = eig_full(A; alg=LAPACK_Simple)
-    @test eltype(D) == eltype(V) == Tc
-    @test A * V ≈ V * D
 end
 
 @testset "eig_trunc! for T = $T" for T in (Float32, Float64, ComplexF32, ComplexF64)

--- a/test/eig.jl
+++ b/test/eig.jl
@@ -8,27 +8,15 @@ using MatrixAlgebraKit: diagview
 @testset "eig_full! for T = $T" for T in (Float32, Float64, ComplexF32, ComplexF64)
     rng = StableRNG(123)
     m = 54
-    for alg in
-        (LAPACK_Simple(), LAPACK_Expert(), LAPACK_Simple, LAPACK_Expert, :LAPACK_Simple,
-         :LAPACK_Expert)
+    for alg in (LAPACK_Simple(), LAPACK_Expert())
         A = randn(rng, T, m, m)
         Tc = complex(T)
 
-        alg′ = if (alg isa Type) || (alg isa Symbol)
-            # These cases aren't inferable right now.
-            MatrixAlgebraKit.select_algorithm(eig_full!, A; alg)
-        else
-            @constinferred MatrixAlgebraKit.select_algorithm(eig_full!, A; alg)
-        end
-
-        D, V = if (alg isa Type) || (alg isa Symbol)
-            # These cases aren't inferable right now.
-            eig_full(A; alg)
-        else
-            @constinferred eig_full(A; alg)
-        end
+        D, V = @constinferred eig_full(A; alg)
         @test eltype(D) == eltype(V) == Tc
         @test A * V ≈ V * D
+
+        alg′ = @constinferred MatrixAlgebraKit.select_algorithm(eig_full!, A, alg)
 
         Ac = similar(A)
         D2, V2 = @constinferred eig_full!(copy!(Ac, A), (D, V), alg′)
@@ -40,6 +28,21 @@ using MatrixAlgebraKit: diagview
         @test eltype(Dc) == Tc
         @test D ≈ Diagonal(Dc)
     end
+
+    # Test other alg inputs.
+    A = randn(rng, T, m, m)
+    Tc = complex(T)
+    D, V = @constinferred eig_full(A; alg=:LAPACK_Simple)
+    @test eltype(D) == eltype(V) == Tc
+    @test A * V ≈ V * D
+
+    A = randn(rng, T, m, m)
+    Tc = complex(T)
+    ## Inference is broken for this case for some reason.
+    ## D, V = @constinferred eig_full(A; alg=LAPACK_Simple)
+    D, V = eig_full(A; alg=LAPACK_Simple)
+    @test eltype(D) == eltype(V) == Tc
+    @test A * V ≈ V * D
 end
 
 @testset "eig_trunc! for T = $T" for T in (Float32, Float64, ComplexF32, ComplexF64)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,8 @@
 using SafeTestsets
 
+@safetestset "Algorithms" begin
+    include("algorithms.jl")
+end
 @safetestset "Truncate" begin
     include("truncate.jl")
 end

--- a/test/svd.jl
+++ b/test/svd.jl
@@ -22,7 +22,12 @@ using MatrixAlgebraKit: TruncationKeepAbove, diagview
             minmn = min(m, n)
             A = randn(rng, T, m, n)
 
-            U, S, Vᴴ = @constinferred svd_compact(A; alg=($alg))
+            if VERSION < v"1.12"
+                # This is type unstable on older versions of Julia.
+                U, S, Vᴴ = svd_compact(A; alg)
+            else
+                U, S, Vᴴ = @constinferred svd_compact(A; alg=($alg))
+            end
             @test U isa Matrix{T} && size(U) == (m, minmn)
             @test S isa Diagonal{real(T)} && size(S) == (minmn, minmn)
             @test Vᴴ isa Matrix{T} && size(Vᴴ) == (minmn, n)

--- a/test/svd.jl
+++ b/test/svd.jl
@@ -22,7 +22,7 @@ using MatrixAlgebraKit: TruncationKeepAbove, diagview
             minmn = min(m, n)
             A = randn(rng, T, m, n)
 
-            if VERSION < v"1.12"
+            if VERSION < v"1.11"
                 # This is type unstable on older versions of Julia.
                 U, S, Vᴴ = svd_compact(A; alg)
             else

--- a/test/svd.jl
+++ b/test/svd.jl
@@ -11,17 +11,18 @@ using MatrixAlgebraKit: TruncationKeepAbove, diagview
     @testset "size ($m, $n)" for n in (37, m, 63)
         k = min(m, n)
         if LinearAlgebra.LAPACK.version() < v"3.12.0"
-            algs = (LAPACK_DivideAndConquer(), LAPACK_QRIteration(), LAPACK_Bisection())
+            algs = (LAPACK_DivideAndConquer(), LAPACK_QRIteration(), LAPACK_Bisection(),
+                    LAPACK_DivideAndConquer, :LAPACK_DivideAndConquer)
         else
             algs = (LAPACK_DivideAndConquer(), LAPACK_QRIteration(), LAPACK_Bisection(),
-                    LAPACK_Jacobi())
+                    LAPACK_Jacobi(), LAPACK_DivideAndConquer, :LAPACK_DivideAndConquer)
         end
         @testset "algorithm $alg" for alg in algs
             n > m && alg isa LAPACK_Jacobi && continue # not supported
             minmn = min(m, n)
             A = randn(rng, T, m, n)
 
-            U, S, Vᴴ = svd_compact(A; alg)
+            U, S, Vᴴ = @constinferred svd_compact(A; alg=($alg))
             @test U isa Matrix{T} && size(U) == (m, minmn)
             @test S isa Diagonal{real(T)} && size(S) == (minmn, minmn)
             @test Vᴴ isa Matrix{T} && size(Vᴴ) == (minmn, n)
@@ -32,7 +33,8 @@ using MatrixAlgebraKit: TruncationKeepAbove, diagview
 
             Ac = similar(A)
             Sc = similar(A, real(T), min(m, n))
-            U2, S2, V2ᴴ = @constinferred svd_compact!(copy!(Ac, A), (U, S, Vᴴ), alg)
+            alg′ = @constinferred MatrixAlgebraKit.select_algorithm(svd_compact!, A, $alg)
+            U2, S2, V2ᴴ = @constinferred svd_compact!(copy!(Ac, A), (U, S, Vᴴ), alg′)
             @test U2 === U
             @test S2 === S
             @test V2ᴴ === Vᴴ
@@ -41,7 +43,7 @@ using MatrixAlgebraKit: TruncationKeepAbove, diagview
             @test Vᴴ * Vᴴ' ≈ I
             @test isposdef(S)
 
-            Sd = svd_vals(A, alg)
+            Sd = @constinferred svd_vals(A, alg′)
             @test S ≈ Diagonal(Sd)
         end
     end


### PR DESCRIPTION
This refactors the algorithm selection logic (`select_algorithm`) in terms of two layers. In this new design, there is a generic function `select_algorithm` for any factorization function and matrix type that processes the `alg` keyword argument, and either uses the algorithm that is specified or if none is specified forwards to a lower level generic function `default_algorithm`, which then chooses a default algorithm depending on the factorization function and matrix type.

The motivation for this was that I started making a PR to make `select_algorithm` stricter about how it handles keyword arguments, but it was cumbersome to do since the `select_algorithm` logic for processing keyword arguments was repeated for each factorization function. In addition, I added logic for allowing an algorithm type (in addition to a Symbol and algorithm object) to be passed as `alg`, which was also easier to implement in the new design.

@lkdvos and I were discussing the naming of these two layers of functions (currently `select_algorithm` and `default_algorithm`), he proposed `select_algorithm` -> `_select_algorithm` and `default_algorithm` -> `select_algorithm`. I'm definitely open to suggestions, curious what you think @Jutho.

To-do:
- [x] Update the docstrings and add docs for `default_algorithm`.
- [x] Dedicated tests for `select_algorithm`/`default_algorithm`.
- [x] Investigate type stability.
- [x] Decide on the names.