### PR TITLE
Support unsorted spectra in `TruncationKeepAbove`/`Below`

### DIFF
--- a/test/truncate.jl
+++ b/test/truncate.jl
@@ -2,7 +2,7 @@ using MatrixAlgebraKit
 using Test
 using TestExtras
 using MatrixAlgebraKit: NoTruncation, TruncationIntersection, TruncationKeepAbove,
-                        TruncationStrategy, findtruncated
+                        TruncationKeepBelow, TruncationStrategy, findtruncated
 
 @testset "truncate" begin
     trunc = @constinferred TruncationStrategy()
@@ -28,7 +28,21 @@ using MatrixAlgebraKit: NoTruncation, TruncationIntersection, TruncationKeepAbov
     @test trunc.components[2] == TruncationKeepAbove(1e-2, 1e-3)
 
     values = [1, 0.9, 0.5, 0.3, 0.01]
-    @test @constinferred(findtruncated(values, truncrank(2))) == [1, 2]
-    @test @constinferred(findtruncated(values, truncrank(2; rev=false))) == [5, 4]
-    @test @constinferred(findtruncated(values, truncrank(2; by=-))) == [5, 4]
+    @test @constinferred(Vector{Int}, findtruncated(values, truncrank(2))) === 1:2
+    @test @constinferred(UnitRange{Int}, findtruncated(values, truncrank(2; rev=false))) ==
+          [5, 4]
+    @test @constinferred(UnitRange{Int}, findtruncated(values, truncrank(2; by=-))) ==
+          [5, 4]
+
+    values = [1, 0.9, 0.5, 0.3, 0.01]
+    @test @constinferred(Vector{Int},
+                         findtruncated(values, TruncationKeepAbove(0.4, 0.0))) === 1:3
+    @test @constinferred(Vector{Int},
+                         findtruncated(values, TruncationKeepBelow(0.4, 0.0))) === 4:5
+
+    values = [0.01, 1, 0.9, 0.3, 0.5]
+    @test @constinferred(UnitRange{Int},
+                         findtruncated(values, TruncationKeepAbove(0.4, 0.0))) == [2, 3, 5]
+    @test @constinferred(UnitRange{Int},
+                         findtruncated(values, TruncationKeepBelow(0.4, 0.0))) == [4, 1]
 end


### PR DESCRIPTION
As the PR title says, this adds support for truncating unsorted spectrum in `TruncationKeepAbove`/`TruncationKeepBelow`.

It also more systematically handles sorted vs. unsorted spectra where relevant by splitting between codepaths `findtruncated_sorted` and `findtruncated_unsorted`, where the sorted version outputs unit ranges.

This has the downside that those cases of `findtruncated` become mildly type unstable (i.e. `Union{Vector{Int},UnitRange{Int}}`), but I think that is worth it since slicing a spectrum/matrix with a unit range is generally faster than slicing with an arbitrary vector.

I'm open to hearing other design ideas as well, an alternative or complement to this could be that certain factorizations indicate to the truncation code that the spectrum is sorted already so it can avoid the check and maybe become type stable.

One motivation for this is that even though the spectrum for an SVD is generally (reverse) sorted, if you do a blockwise SVD of a block diagonal matrix the spectra are only sorted within blocks, this PR helps with handling that case.