### PR TITLE
Allow customizing `truncate!` based on the algorithm

### DIFF
--- a/src/implementations/eig.jl
+++ b/src/implementations/eig.jl
@@ -84,5 +84,5 @@ end
 
 function eig_trunc!(A::AbstractMatrix, DV, alg::TruncatedAlgorithm)
     D, V = eig_full!(A, DV, alg.alg)
-    return truncate!(eig_trunc!, (D, V), alg.trunc)
+    return truncate!(eig_trunc!, (D, V), alg)
 end

--- a/src/implementations/eigh.jl
+++ b/src/implementations/eigh.jl
@@ -86,5 +86,5 @@ end
 
 function eigh_trunc!(A::AbstractMatrix, DV, alg::TruncatedAlgorithm)
     D, V = eigh_full!(A, DV, alg.alg)
-    return truncate!(eigh_trunc!, (D, V), alg.trunc)
+    return truncate!(eigh_trunc!, (D, V), alg)
 end

--- a/src/implementations/orthnull.jl
+++ b/src/implementations/orthnull.jl
@@ -180,7 +180,7 @@ function left_null!(A::AbstractMatrix, N; trunc=nothing,
         trunc′ = trunc isa TruncationStrategy ? trunc :
                  trunc isa NamedTuple ? null_truncation_strategy(; trunc...) :
                  throw(ArgumentError("Unknown truncation strategy: $trunc"))
-        return truncate!(left_null!, (U, S), trunc′)
+        return truncate!(left_null!, (U, S), TruncatedAlgorithm(alg_svd′, trunc′))
     else
         throw(ArgumentError("`left_null!` received unknown value `kind = $kind`"))
     end
@@ -207,7 +207,7 @@ function right_null!(A::AbstractMatrix, Nᴴ; trunc=nothing,
         trunc′ = trunc isa TruncationStrategy ? trunc :
                  trunc isa NamedTuple ? null_truncation_strategy(; trunc...) :
                  throw(ArgumentError("Unknown truncation strategy: $trunc"))
-        return truncate!(right_null!, (S, Vᴴ), trunc′)
+        return truncate!(right_null!, (S, Vᴴ), TruncatedAlgorithm(alg_svd′, trunc′))
     else
         throw(ArgumentError("`right_null!` received unknown value `kind = $kind`"))
     end

--- a/src/implementations/svd.jl
+++ b/src/implementations/svd.jl
@@ -170,5 +170,5 @@ end
 
 function svd_trunc!(A::AbstractMatrix, USVᴴ, alg::TruncatedAlgorithm)
     USVᴴ′ = svd_compact!(A, USVᴴ, alg.alg)
-    return truncate!(svd_trunc!, USVᴴ′, alg.trunc)
+    return truncate!(svd_trunc!, USVᴴ′, alg)
 end


### PR DESCRIPTION
Closes #27.

The idea here is that this allows customizing the truncation based on the algorithm if needed, in addition to the truncation strategy. The reasoning is that certain algorithm backends might output the spectrum in a different format/ordering, which would require a different implementation of the truncation.

I'm open to suggestions on other ways of implementing this. Right now it is based on passing the `TruncatedAlgorithm` object into `truncate!`, which includes both the algorithm and the truncation strategy, and then by default it unwraps just the truncation strategy. An alternative could be to pass the truncation strategy and algorithm as separate arguments, though in general they might not be separate, for example in a sparse/low rank factorization like a randomized SVD or Krylov SVD.