### PR TITLE
Refactor algorithm selection in type domain

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MatrixAlgebraKit"
 uuid = "6c742aac-3347-4629-af66-fc926824e5e4"
 authors = ["Jutho <jutho.haegeman@ugent.be> and contributors"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -36,4 +36,5 @@ TestExtras = "5ed8adda-3752-4e41-b88a-e8b09835ee3a"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["Aqua", "JET", "SafeTestsets", "Test", "TestExtras","ChainRulesCore", "ChainRulesTestUtils", "StableRNGs", "Zygote"]
+test = ["Aqua", "JET", "SafeTestsets", "Test", "TestExtras", "ChainRulesCore",
+        "ChainRulesTestUtils", "StableRNGs", "Zygote"]

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -73,8 +73,7 @@ automatically with [`MatrixAlgebraKit.default_algorithm`](@ref) and
 the keyword arguments in `kwargs` will be passed to the algorithm constructor.
 Finally, the same behavior is obtained when the keyword arguments are
 passed as the third positional argument in the form of a `NamedTuple`. 
-"""
-function select_algorithm end
+""" select_algorithm
 
 function select_algorithm(f::F, A, alg::Alg=nothing; kwargs...) where {F,Alg}
     return _select_algorithm(f, A, alg; kwargs...)
@@ -109,8 +108,7 @@ end
 Select the default algorithm for a given factorization function `f` and input `A`.
 In general, this is called by [`select_algorithm`](@ref) if no algorithm is specified
 explicitly.
-"""
-function default_algorithm end
+""" default_algorithm
 
 @doc """
     copy_input(f, A)
@@ -118,8 +116,7 @@ function default_algorithm end
 Preprocess the input `A` for a given function, such that it may be handled correctly later.
 This may include a copy whenever the implementation would destroy the original matrix,
 or a change of element type to something that is supported.
-"""
-function copy_input end
+""" copy_input
 
 @doc """
     initialize_output(f, A, alg)
@@ -127,8 +124,7 @@ function copy_input end
 Whenever possible, allocate the destination for applying a given algorithm in-place.
 If this is not possible, for example when the output size is not known a priori or immutable,
 this function may return `nothing`.
-"""
-function initialize_output end
+""" initialize_output
 
 # Utility macros
 # --------------

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -197,6 +197,14 @@ macro functiondef(f)
             return $f!(A, initialize_output($f!, A, alg), alg)
         end
 
+        # define fallbacks for algorithm selection
+        @inline function select_algorithm(::typeof($f), A, alg::Alg; kwargs...) where {Alg}
+            return select_algorithm($f!, A, alg; kwargs...)
+        end
+        @inline function default_algorithm(::typeof($f), A; kwargs...)
+            return default_algorithm($f!, A; kwargs...)
+        end
+
         # copy documentation to both functions
         Core.@__doc__ $f, $f!
     end

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -80,31 +80,25 @@ function select_algorithm(f::F, A, alg::Alg=nothing; kwargs...) where {F,Alg}
     return select_algorithm(f, typeof(A), alg; kwargs...)
 end
 function select_algorithm(f::F, ::Type{A}, alg::Alg=nothing; kwargs...) where {F,A,Alg}
-    return _select_algorithm(f, A, alg; kwargs...)
+    if isnothing(alg)
+        return default_algorithm(f, A; kwargs...)
+    elseif alg isa Symbol
+        return Algorithm{alg}(; kwargs...)
+    elseif alg isa Type
+        return alg(; kwargs...)
+    elseif alg isa NamedTuple
+        isempty(kwargs) ||
+            throw(ArgumentError("Additional keyword arguments are not allowed when algorithm parameters are specified."))
+        return default_algorithm(f, A; alg...)
+    elseif alg isa AbstractAlgorithm
+        isempty(kwargs) ||
+            throw(ArgumentError("Additional keyword arguments are not allowed when algorithm parameters are specified."))
+        return alg
+    end
+
+    throw(ArgumentError("Unknown alg $alg"))
 end
 
-function _select_algorithm(f::F, ::Type{A}, alg::Nothing; kwargs...) where {F,A}
-    return default_algorithm(f, A; kwargs...)
-end
-function _select_algorithm(f::F, ::Type{A}, alg::Symbol; kwargs...) where {F,A}
-    return Algorithm{alg}(; kwargs...)
-end
-function _select_algorithm(f::F, ::Type{A}, ::Type{Alg}; kwargs...) where {F,A,Alg}
-    return Alg(; kwargs...)
-end
-function _select_algorithm(f::F, ::Type{A}, alg::NamedTuple; kwargs...) where {F,A}
-    isempty(kwargs) ||
-        throw(ArgumentError("Additional keyword arguments are not allowed when algorithm parameters are specified."))
-    return default_algorithm(f, A; alg...)
-end
-function _select_algorithm(f::F, ::Type{A}, alg::AbstractAlgorithm; kwargs...) where {F,A}
-    isempty(kwargs) ||
-        throw(ArgumentError("Additional keyword arguments are not allowed when an algorithm is specified."))
-    return alg
-end
-function _select_algorithm(f::F, ::Type{A}, alg; kwargs...) where {F,A}
-    return throw(ArgumentError("Unknown alg $alg"))
-end
 
 @doc """
     MatrixAlgebraKit.default_algorithm(f, A; kwargs...)

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -117,7 +117,9 @@ New types should prefer to register their default algorithms in the type domain.
 """ default_algorithm
 default_algorithm(f::F, A; kwargs...) where {F} = default_algorithm(f, typeof(A); kwargs...)
 # avoid infinite recursion:
-default_algorithm(f, T::Type; kwargs...) = throw(MethodError(default_algorithm, (f, T)))
+function default_algorithm(f::F, ::Type{T}; kwargs...) where {F,T}
+    throw(MethodError(default_algorithm, (f, T)))
+end
 
 @doc """
     copy_input(f, A)
@@ -198,10 +200,11 @@ macro functiondef(f)
         end
 
         # define fallbacks for algorithm selection
-        @inline function select_algorithm(::typeof($f), A, alg::Alg; kwargs...) where {Alg}
+        @inline function select_algorithm(::typeof($f), ::Type{A}, alg::Alg;
+                                          kwargs...) where {Alg,A}
             return select_algorithm($f!, A, alg; kwargs...)
         end
-        @inline function default_algorithm(::typeof($f), A; kwargs...)
+        @inline function default_algorithm(::typeof($f), ::Type{A}; kwargs...) where {A}
             return default_algorithm($f!, A; kwargs...)
         end
 

--- a/src/interface/eig.jl
+++ b/src/interface/eig.jl
@@ -87,27 +87,18 @@ See also [`eig_full(!)`](@ref eig_full) and [`eig_trunc(!)`](@ref eig_trunc).
 
 # Algorithm selection
 # -------------------
-for f in (:eig_full, :eig_vals)
-    f! = Symbol(f, :!)
-    @eval begin
-        function default_algorithm(::typeof($f), A; kwargs...)
-            return default_algorithm($f!, A; kwargs...)
-        end
-        function default_algorithm(::typeof($f!), A; kwargs...)
-            return default_eig_algorithm(A; kwargs...)
-        end
-    end
+# Default to LAPACK for `StridedMatrix{<:BlasFloat}`
+function default_algorithm(::typeof(eig_full!), ::Type{A};
+                           kwargs...) where {A<:StridedMatrix{<:BlasFloat}}
+    return LAPACK_Expert(; kwargs...)
+end
+function default_algorithm(::typeof(eig_vals!), ::Type{A};
+                           kwargs...) where {A<:StridedMatrix{<:BlasFloat}}
+    return LAPACK_Expert(; kwargs...)
 end
 
-function select_algorithm(::typeof(eig_trunc), A, alg; kwargs...)
-    return select_algorithm(eig_trunc!, A, alg; kwargs...)
-end
-function select_algorithm(::typeof(eig_trunc!), A, alg; trunc=nothing, kwargs...)
+function select_algorithm(::typeof(eig_trunc!), ::Type{A}, alg; trunc=nothing,
+                          kwargs...) where {A<:StridedMatrix{<:BlasFloat}}
     alg_eig = select_algorithm(eig_full!, A, alg; kwargs...)
     return TruncatedAlgorithm(alg_eig, select_truncation(trunc))
-end
-
-# Default to LAPACK 
-function default_eig_algorithm(A::StridedMatrix{<:BlasFloat}; kwargs...)
-    return LAPACK_Expert(; kwargs...)
 end

--- a/src/interface/eig.jl
+++ b/src/interface/eig.jl
@@ -87,18 +87,18 @@ See also [`eig_full(!)`](@ref eig_full) and [`eig_trunc(!)`](@ref eig_trunc).
 
 # Algorithm selection
 # -------------------
-# Default to LAPACK for `StridedMatrix{<:BlasFloat}`
+# Default to LAPACK for `YALAPACK.BlasMat`
 function default_algorithm(::typeof(eig_full!), ::Type{A};
-                           kwargs...) where {A<:StridedMatrix{<:BlasFloat}}
+                           kwargs...) where {A<:YALAPACK.BlasMat}
     return LAPACK_Expert(; kwargs...)
 end
 function default_algorithm(::typeof(eig_vals!), ::Type{A};
-                           kwargs...) where {A<:StridedMatrix{<:BlasFloat}}
+                           kwargs...) where {A<:YALAPACK.BlasMat}
     return LAPACK_Expert(; kwargs...)
 end
 
 function select_algorithm(::typeof(eig_trunc!), ::Type{A}, alg; trunc=nothing,
-                          kwargs...) where {A<:StridedMatrix{<:BlasFloat}}
+                          kwargs...) where {A<:YALAPACK.BlasMat}
     alg_eig = select_algorithm(eig_full!, A, alg; kwargs...)
     return TruncatedAlgorithm(alg_eig, select_truncation(trunc))
 end

--- a/src/interface/eig.jl
+++ b/src/interface/eig.jl
@@ -87,14 +87,16 @@ See also [`eig_full(!)`](@ref eig_full) and [`eig_trunc(!)`](@ref eig_trunc).
 
 # Algorithm selection
 # -------------------
-# Default to LAPACK for `YALAPACK.BlasMat`
-function default_algorithm(::typeof(eig_full!), ::Type{A};
-                           kwargs...) where {A<:YALAPACK.BlasMat}
+default_eig_algorithm(A; kwargs...) = default_eig_algorithm(typeof(A); kwargs...)
+default_eig_algorithm(T::Type; kwargs...) = throw(MethodError(default_eig_algorithm, (T,)))
+function default_eig_algorithm(::Type{T}; kwargs...) where {T<:YALAPACK.BlasMat}
     return LAPACK_Expert(; kwargs...)
 end
-function default_algorithm(::typeof(eig_vals!), ::Type{A};
-                           kwargs...) where {A<:YALAPACK.BlasMat}
-    return LAPACK_Expert(; kwargs...)
+
+for f in (:eig_full!, :eig_vals!)
+    @eval function default_algorithm(::typeof($f), ::Type{A}; kwargs...) where {A}
+        return default_eig_algorithm(A; kwargs...)
+    end
 end
 
 function select_algorithm(::typeof(eig_trunc!), ::Type{A}, alg; trunc=nothing,

--- a/src/interface/eigh.jl
+++ b/src/interface/eigh.jl
@@ -86,14 +86,18 @@ See also [`eigh_full(!)`](@ref eigh_full) and [`eigh_trunc(!)`](@ref eigh_trunc)
 
 # Algorithm selection
 # -------------------
-# Default to LAPACK for `YALAPACK.BlasMat`
-function default_algorithm(::typeof(eigh_full!), ::Type{A};
-                           kwargs...) where {A<:YALAPACK.BlasMat}
+default_eigh_algorithm(A; kwargs...) = default_eigh_algorithm(typeof(A); kwargs...)
+function default_eigh_algorithm(T::Type; kwargs...)
+    throw(MethodError(default_eigh_algorithm, (T,)))
+end
+function default_eigh_algorithm(::Type{T}; kwargs...) where {T<:YALAPACK.BlasMat}
     return LAPACK_MultipleRelativelyRobustRepresentations(; kwargs...)
 end
-function default_algorithm(::typeof(eigh_vals!), ::Type{A};
-                           kwargs...) where {A<:YALAPACK.BlasMat}
-    return LAPACK_MultipleRelativelyRobustRepresentations(; kwargs...)
+
+for f in (:eigh_full!, :eigh_vals!)
+    @eval function default_algorithm(::typeof($f), ::Type{A}; kwargs...) where {A}
+        return default_eigh_algorithm(A; kwargs...)
+    end
 end
 
 function select_algorithm(::typeof(eigh_trunc!), ::Type{A}, alg; trunc=nothing,

--- a/src/interface/eigh.jl
+++ b/src/interface/eigh.jl
@@ -86,18 +86,18 @@ See also [`eigh_full(!)`](@ref eigh_full) and [`eigh_trunc(!)`](@ref eigh_trunc)
 
 # Algorithm selection
 # -------------------
-# Default to LAPACK for `StridedMatrix{<:BlasFloat}`
+# Default to LAPACK for `YALAPACK.BlasMat`
 function default_algorithm(::typeof(eigh_full!), ::Type{A};
-                           kwargs...) where {A<:StridedMatrix{<:BlasFloat}}
+                           kwargs...) where {A<:YALAPACK.BlasMat}
     return LAPACK_MultipleRelativelyRobustRepresentations(; kwargs...)
 end
 function default_algorithm(::typeof(eigh_vals!), ::Type{A};
-                           kwargs...) where {A<:StridedMatrix{<:BlasFloat}}
+                           kwargs...) where {A<:YALAPACK.BlasMat}
     return LAPACK_MultipleRelativelyRobustRepresentations(; kwargs...)
 end
 
 function select_algorithm(::typeof(eigh_trunc!), ::Type{A}, alg; trunc=nothing,
-                          kwargs...) where {A<:StridedMatrix{<:BlasFloat}}
+                          kwargs...) where {A<:YALAPACK.BlasMat}
     alg_eigh = select_algorithm(eigh_full!, A, alg; kwargs...)
     return TruncatedAlgorithm(alg_eigh, select_truncation(trunc))
 end

--- a/src/interface/eigh.jl
+++ b/src/interface/eigh.jl
@@ -86,27 +86,18 @@ See also [`eigh_full(!)`](@ref eigh_full) and [`eigh_trunc(!)`](@ref eigh_trunc)
 
 # Algorithm selection
 # -------------------
-for f in (:eigh_full, :eigh_vals)
-    f! = Symbol(f, :!)
-    @eval begin
-        function default_algorithm(::typeof($f), A; kwargs...)
-            return default_algorithm($f!, A; kwargs...)
-        end
-        function default_algorithm(::typeof($f!), A; kwargs...)
-            return default_eigh_algorithm(A; kwargs...)
-        end
-    end
+# Default to LAPACK for `StridedMatrix{<:BlasFloat}`
+function default_algorithm(::typeof(eigh_full!), ::Type{A};
+                           kwargs...) where {A<:StridedMatrix{<:BlasFloat}}
+    return LAPACK_MultipleRelativelyRobustRepresentations(; kwargs...)
+end
+function default_algorithm(::typeof(eigh_vals!), ::Type{A};
+                           kwargs...) where {A<:StridedMatrix{<:BlasFloat}}
+    return LAPACK_MultipleRelativelyRobustRepresentations(; kwargs...)
 end
 
-function select_algorithm(::typeof(eigh_trunc), A, alg; kwargs...)
-    return select_algorithm(eigh_trunc!, A, alg; kwargs...)
-end
-function select_algorithm(::typeof(eigh_trunc!), A, alg; trunc=nothing, kwargs...)
+function select_algorithm(::typeof(eigh_trunc!), ::Type{A}, alg; trunc=nothing,
+                          kwargs...) where {A<:StridedMatrix{<:BlasFloat}}
     alg_eigh = select_algorithm(eigh_full!, A, alg; kwargs...)
     return TruncatedAlgorithm(alg_eigh, select_truncation(trunc))
-end
-
-# Default to LAPACK 
-function default_eigh_algorithm(A::StridedMatrix{T}; kwargs...) where {T<:BlasFloat}
-    return LAPACK_MultipleRelativelyRobustRepresentations(; kwargs...)
 end

--- a/src/interface/lq.jl
+++ b/src/interface/lq.jl
@@ -71,7 +71,7 @@ See also [`qr_full(!)`](@ref lq_full) and [`qr_compact(!)`](@ref lq_compact).
 for f in (:lq_full!, :lq_compact!, :lq_null!)
     @eval begin
         function default_algorithm(::typeof($f), ::Type{A};
-                                   kwargs...) where {A<:StridedMatrix{<:BlasFloat}}
+                                   kwargs...) where {A<:YALAPACK.BlasMat}
             return LAPACK_HouseholderLQ(; kwargs...)
         end
     end

--- a/src/interface/lq.jl
+++ b/src/interface/lq.jl
@@ -68,11 +68,18 @@ See also [`qr_full(!)`](@ref lq_full) and [`qr_compact(!)`](@ref lq_compact).
 
 # Algorithm selection
 # -------------------
+default_lq_algorithm(A; kwargs...) = default_lq_algorithm(typeof(A); kwargs...)
+function default_lq_algorithm(T::Type; kwargs...)
+    throw(MethodError(default_lq_algorithm, (T,)))
+end
+function default_lq_algorithm(::Type{T}; kwargs...) where {T<:YALAPACK.BlasMat}
+    return LAPACK_HouseholderLQ(; kwargs...)
+end
+
 for f in (:lq_full!, :lq_compact!, :lq_null!)
     @eval begin
-        function default_algorithm(::typeof($f), ::Type{A};
-                                   kwargs...) where {A<:YALAPACK.BlasMat}
-            return LAPACK_HouseholderLQ(; kwargs...)
+        function default_algorithm(::typeof($f), ::Type{A}; kwargs...) where {A}
+            return default_lq_algorithm(A; kwargs...)
         end
     end
 end

--- a/src/interface/lq.jl
+++ b/src/interface/lq.jl
@@ -68,19 +68,11 @@ See also [`qr_full(!)`](@ref lq_full) and [`qr_compact(!)`](@ref lq_compact).
 
 # Algorithm selection
 # -------------------
-for f in (:lq_full, :lq_compact, :lq_null)
-    f! = Symbol(f, :!)
+for f in (:lq_full!, :lq_compact!, :lq_null!)
     @eval begin
-        function default_algorithm(::typeof($f), A; kwargs...)
-            return default_algorithm($f!, A; kwargs...)
-        end
-        function default_algorithm(::typeof($f!), A; kwargs...)
-            return default_lq_algorithm(A; kwargs...)
+        function default_algorithm(::typeof($f), ::Type{A};
+                                   kwargs...) where {A<:StridedMatrix{<:BlasFloat}}
+            return LAPACK_HouseholderLQ(; kwargs...)
         end
     end
-end
-
-# Default to LAPACK 
-function default_lq_algorithm(A::StridedMatrix{<:BlasFloat}; kwargs...)
-    return LAPACK_HouseholderLQ(; kwargs...)
 end

--- a/src/interface/polar.jl
+++ b/src/interface/polar.jl
@@ -60,11 +60,16 @@ end
 
 # Algorithm selection
 # -------------------
-function default_algorithm(::typeof(left_polar!), ::Type{A};
-                           kwargs...) where {A<:YALAPACK.BlasMat}
-    return PolarViaSVD(default_algorithm(svd_compact!, A; kwargs...))
-        end
-function default_algorithm(::typeof(right_polar!), ::Type{A};
-                           kwargs...) where {A<:YALAPACK.BlasMat}
-    return PolarViaSVD(default_algorithm(svd_compact!, A; kwargs...))
+default_polar_algorithm(A; kwargs...) = default_polar_algorithm(typeof(A); kwargs...)
+function default_polar_algorithm(T::Type; kwargs...)
+    throw(MethodError(default_polar_algorithm, (T,)))
+end
+function default_polar_algorithm(::Type{T}; kwargs...) where {T<:YALAPACK.BlasMat}
+    return PolarViaSVD(default_algorithm(svd_compact!, T; kwargs...))
+end
+
+for f in (:left_polar!, :right_polar!)
+    @eval function default_algorithm(::typeof($f), ::Type{A}; kwargs...) where {A}
+        return default_polar_algorithm(A; kwargs...)
+    end
 end

--- a/src/interface/polar.jl
+++ b/src/interface/polar.jl
@@ -61,10 +61,10 @@ end
 # Algorithm selection
 # -------------------
 function default_algorithm(::typeof(left_polar!), ::Type{A};
-                           kwargs...) where {A<:StridedMatrix{<:BlasFloat}}
+                           kwargs...) where {A<:YALAPACK.BlasMat}
     return PolarViaSVD(default_algorithm(svd_compact!, A; kwargs...))
         end
 function default_algorithm(::typeof(right_polar!), ::Type{A};
-                           kwargs...) where {A<:StridedMatrix{<:BlasFloat}}
+                           kwargs...) where {A<:YALAPACK.BlasMat}
     return PolarViaSVD(default_algorithm(svd_compact!, A; kwargs...))
 end

--- a/src/interface/polar.jl
+++ b/src/interface/polar.jl
@@ -60,19 +60,11 @@ end
 
 # Algorithm selection
 # -------------------
-for f in (:left_polar, :right_polar)
-    f! = Symbol(f, :!)
-    @eval begin
-        function default_algorithm(::typeof($f), A; kwargs...)
-            return default_algorithm($f!, A; kwargs...)
+function default_algorithm(::typeof(left_polar!), ::Type{A};
+                           kwargs...) where {A<:StridedMatrix{<:BlasFloat}}
+    return PolarViaSVD(default_algorithm(svd_compact!, A; kwargs...))
         end
-        function default_algorithm(::typeof($f!), A; kwargs...)
-            return default_polar_algorithm(A; kwargs...)
-        end
-    end
-end
-
-# Default to LAPACK SDD for `StridedMatrix{<:BlasFloat}`
-function default_polar_algorithm(A::StridedMatrix{<:BlasFloat}; kwargs...)
-    return PolarViaSVD(default_svd_algorithm(A; kwargs...))
+function default_algorithm(::typeof(right_polar!), ::Type{A};
+                           kwargs...) where {A<:StridedMatrix{<:BlasFloat}}
+    return PolarViaSVD(default_algorithm(svd_compact!, A; kwargs...))
 end

--- a/src/interface/qr.jl
+++ b/src/interface/qr.jl
@@ -68,19 +68,11 @@ See also [`lq_full(!)`](@ref lq_full) and [`lq_compact(!)`](@ref lq_compact).
 
 # Algorithm selection
 # -------------------
-for f in (:qr_full, :qr_compact, :qr_null)
-    f! = Symbol(f, :!)
+for f in (:qr_full!, :qr_compact!, :qr_null!)
     @eval begin
-        function default_algorithm(::typeof($f), A; kwargs...)
-            return default_algorithm($f!, A; kwargs...)
-        end
-        function default_algorithm(::typeof($f!), A; kwargs...)
-            return default_qr_algorithm(A; kwargs...)
+        function default_algorithm(::typeof($f), ::Type{A};
+                                   kwargs...) where {A<:StridedMatrix{<:BlasFloat}}
+            return LAPACK_HouseholderQR(; kwargs...)
         end
     end
-end
-
-# Default to LAPACK 
-function default_qr_algorithm(A::StridedMatrix{<:BlasFloat}; kwargs...)
-    return LAPACK_HouseholderQR(; kwargs...)
 end

--- a/src/interface/qr.jl
+++ b/src/interface/qr.jl
@@ -68,11 +68,19 @@ See also [`lq_full(!)`](@ref lq_full) and [`lq_compact(!)`](@ref lq_compact).
 
 # Algorithm selection
 # -------------------
+default_qr_algorithm(A; kwargs...) = default_qr_algorithm(typeof(A); kwargs...)
+function default_qr_algorithm(T::Type; kwargs...)
+    throw(MethodError(default_qr_algorithm, (T,)))
+end
+function default_qr_algorithm(::Type{T}; kwargs...) where {T<:YALAPACK.BlasMat}
+    return LAPACK_HouseholderQR(; kwargs...)
+end
+
 for f in (:qr_full!, :qr_compact!, :qr_null!)
     @eval begin
         function default_algorithm(::typeof($f), ::Type{A};
                                    kwargs...) where {A<:YALAPACK.BlasMat}
-            return LAPACK_HouseholderQR(; kwargs...)
+            return default_qr_algorithm(A; kwargs...)
         end
     end
 end

--- a/src/interface/qr.jl
+++ b/src/interface/qr.jl
@@ -71,7 +71,7 @@ See also [`lq_full(!)`](@ref lq_full) and [`lq_compact(!)`](@ref lq_compact).
 for f in (:qr_full!, :qr_compact!, :qr_null!)
     @eval begin
         function default_algorithm(::typeof($f), ::Type{A};
-                                   kwargs...) where {A<:StridedMatrix{<:BlasFloat}}
+                                   kwargs...) where {A<:YALAPACK.BlasMat}
             return LAPACK_HouseholderQR(; kwargs...)
         end
     end

--- a/src/interface/schur.jl
+++ b/src/interface/schur.jl
@@ -52,10 +52,10 @@ See also [`eig_full(!)`](@ref eig_full) and [`eig_trunc(!)`](@ref eig_trunc).
 # Algorithm selection
 # -------------------
 function default_algorithm(::typeof(schur_full!), ::Type{A};
-                           kwargs...) where {A<:StridedMatrix{<:BlasFloat}}
+                           kwargs...) where {A<:YALAPACK.BlasMat}
     return default_algorithm(eig_full!, A; kwargs...)
 end
 function default_algorithm(::typeof(schur_vals!), ::Type{A};
-                           kwargs...) where {A<:StridedMatrix{<:BlasFloat}}
+                           kwargs...) where {A<:YALAPACK.BlasMat}
     return default_algorithm(eig_vals!, A; kwargs...)
 end

--- a/src/interface/schur.jl
+++ b/src/interface/schur.jl
@@ -51,11 +51,8 @@ See also [`eig_full(!)`](@ref eig_full) and [`eig_trunc(!)`](@ref eig_trunc).
 
 # Algorithm selection
 # -------------------
-function default_algorithm(::typeof(schur_full!), ::Type{A};
-                           kwargs...) where {A<:YALAPACK.BlasMat}
-    return default_algorithm(eig_full!, A; kwargs...)
-end
-function default_algorithm(::typeof(schur_vals!), ::Type{A};
-                           kwargs...) where {A<:YALAPACK.BlasMat}
-    return default_algorithm(eig_vals!, A; kwargs...)
+for f in (:schur_full!, :schur_vals!)
+    @eval function default_algorithm(::typeof($f), ::Type{A}; kwargs...) where {A}
+        return default_eig_algorithm(A; kwargs...)
+    end
 end

--- a/src/interface/schur.jl
+++ b/src/interface/schur.jl
@@ -51,14 +51,11 @@ See also [`eig_full(!)`](@ref eig_full) and [`eig_trunc(!)`](@ref eig_trunc).
 
 # Algorithm selection
 # -------------------
-for f in (:schur_full, :schur_vals)
-    f! = Symbol(f, :!)
-    @eval begin
-        function default_algorithm(::typeof($f), A; kwargs...)
-            return default_algorithm($f!, A; kwargs...)
-        end
-        function default_algorithm(::typeof($f!), A; kwargs...)
-            return default_eig_algorithm(A; kwargs...)
-        end
-    end
+function default_algorithm(::typeof(schur_full!), ::Type{A};
+                           kwargs...) where {A<:StridedMatrix{<:BlasFloat}}
+    return default_algorithm(eig_full!, A; kwargs...)
+end
+function default_algorithm(::typeof(schur_vals!), ::Type{A};
+                           kwargs...) where {A<:StridedMatrix{<:BlasFloat}}
+    return default_algorithm(eig_vals!, A; kwargs...)
 end

--- a/src/interface/svd.jl
+++ b/src/interface/svd.jl
@@ -90,11 +90,17 @@ See also [`svd_full(!)`](@ref svd_full), [`svd_compact(!)`](@ref svd_compact) an
 
 # Algorithm selection
 # -------------------
+default_svd_algorithm(A; kwargs...) = default_svd_algorithm(typeof(A); kwargs...)
+function default_svd_algorithm(T::Type; kwargs...)
+    throw(MethodError(default_svd_algorithm, (T,)))
+end
+function default_svd_algorithm(::Type{T}; kwargs...) where {T<:YALAPACK.BlasMat}
+    return LAPACK_DivideAndConquer(; kwargs...)
+end
+
 for f in (:svd_full!, :svd_compact!, :svd_vals!)
-    # Default to LAPACK SDD for `YALAPACK.BlasMat`
-    @eval function default_algorithm(::typeof($f), ::Type{A};
-                                     kwargs...) where {A<:YALAPACK.BlasMat}
-        return LAPACK_DivideAndConquer(; kwargs...)
+    @eval function default_algorithm(::typeof($f), ::Type{A}; kwargs...) where {A}
+        return default_svd_algorithm(A; kwargs...)
     end
 end
 

--- a/src/interface/svd.jl
+++ b/src/interface/svd.jl
@@ -91,15 +91,15 @@ See also [`svd_full(!)`](@ref svd_full), [`svd_compact(!)`](@ref svd_compact) an
 # Algorithm selection
 # -------------------
 for f in (:svd_full!, :svd_compact!, :svd_vals!)
-    # Default to LAPACK SDD for `StridedMatrix{<:BlasFloat}`
+    # Default to LAPACK SDD for `YALAPACK.BlasMat`
     @eval function default_algorithm(::typeof($f), ::Type{A};
-                                     kwargs...) where {A<:StridedMatrix{<:BlasFloat}}
+                                     kwargs...) where {A<:YALAPACK.BlasMat}
         return LAPACK_DivideAndConquer(; kwargs...)
     end
 end
 
 function select_algorithm(::typeof(svd_trunc!), ::Type{A}, alg; trunc=nothing,
-                          kwargs...) where {A<:StridedMatrix{<:BlasFloat}}
+                          kwargs...) where {A<:YALAPACK.BlasMat}
     alg_svd = select_algorithm(svd_compact!, A, alg; kwargs...)
     return TruncatedAlgorithm(alg_svd, select_truncation(trunc))
 end

--- a/src/yalapack.jl
+++ b/src/yalapack.jl
@@ -16,6 +16,9 @@ using LinearAlgebra: BlasFloat, BlasReal, BlasComplex, BlasInt, Char, LAPACK,
 using LinearAlgebra.BLAS: @blasfunc, libblastrampoline
 using LinearAlgebra.LAPACK: chkfinite, chktrans, chkside, chkuplofinite, chklapackerror
 
+# type alias for matrices that are definitely supported by YALAPACK
+const BlasMat{T<:BlasFloat} = StridedMatrix{T}
+
 # LU factorisation
 for (getrf, getrs, elty) in ((:dgetrf_, :dgetrs_, :Float64),
                              (:sgetrf_, :sgetrs_, :Float32),

--- a/test/orthnull.jl
+++ b/test/orthnull.jl
@@ -4,7 +4,7 @@ using TestExtras
 using StableRNGs
 using LinearAlgebra: LinearAlgebra, I, mul!
 using MatrixAlgebraKit: TruncationKeepAbove, TruncationKeepBelow
-using MatrixAlgebraKit: LAPACK_SVDAlgorithm, check_input, copy_input, default_algorithm,
+using MatrixAlgebraKit: LAPACK_SVDAlgorithm, check_input, copy_input, default_svd_algorithm,
                         initialize_output
 
 # Used to test non-AbstractMatrix codepaths.
@@ -39,9 +39,8 @@ end
 function MatrixAlgebraKit.check_input(::typeof(right_orth!), A::LinearMap, VC)
     return check_input(right_orth!, parent(A), parent.(VC))
 end
-function MatrixAlgebraKit.default_algorithm(::typeof(svd_compact!),
-                                            ::Type{LinearMap{A}}) where {A}
-    return default_algorithm(svd_compact!, A)
+function MatrixAlgebraKit.default_svd_algorithm(::Type{LinearMap{A}}; kwargs...) where {A}
+    return default_svd_algorithm(A; kwargs...)
 end
 function MatrixAlgebraKit.initialize_output(::typeof(svd_compact!), A::LinearMap,
                                             alg::LAPACK_SVDAlgorithm)

--- a/test/orthnull.jl
+++ b/test/orthnull.jl
@@ -4,7 +4,7 @@ using TestExtras
 using StableRNGs
 using LinearAlgebra: LinearAlgebra, I, mul!
 using MatrixAlgebraKit: TruncationKeepAbove, TruncationKeepBelow
-using MatrixAlgebraKit: LAPACK_SVDAlgorithm, check_input, copy_input, default_svd_algorithm,
+using MatrixAlgebraKit: LAPACK_SVDAlgorithm, check_input, copy_input, default_algorithm,
                         initialize_output
 
 # Used to test non-AbstractMatrix codepaths.
@@ -39,8 +39,9 @@ end
 function MatrixAlgebraKit.check_input(::typeof(right_orth!), A::LinearMap, VC)
     return check_input(right_orth!, parent(A), parent.(VC))
 end
-function MatrixAlgebraKit.default_svd_algorithm(A::LinearMap)
-    return default_svd_algorithm(parent(A))
+function MatrixAlgebraKit.default_algorithm(::typeof(svd_compact!),
+                                            ::Type{LinearMap{A}}) where {A}
+    return default_algorithm(svd_compact!, A)
 end
 function MatrixAlgebraKit.initialize_output(::typeof(svd_compact!), A::LinearMap,
                                             alg::LAPACK_SVDAlgorithm)


### PR DESCRIPTION
This alters the algorithm selection and default algorithms to be implemented in the type domain instead.
While doing this, I also realized that the new `default_algorithm(f, ...)` and `default_f_alg` are tautologous, so I removed the latter.
Given that these were not public, and the implementations in the "value domain" still dispatch to the type domain, I think this is non-breaking, so should be v0.2.1.


Fixes #29.