### PR TITLE
[WIP] FillArrays extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,21 +1,24 @@
 name = "MatrixAlgebraKit"
 uuid = "6c742aac-3347-4629-af66-fc926824e5e4"
 authors = ["Jutho <jutho.haegeman@ugent.be> and contributors"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [weakdeps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 
 [extensions]
 MatrixAlgebraKitChainRulesCoreExt = "ChainRulesCore"
+MatrixAlgebraKitFillArraysExt = "FillArrays"
 
 [compat]
 Aqua = "0.6, 0.7, 0.8"
 ChainRulesCore = "1"
 ChainRulesTestUtils = "1"
+FillArrays = "1"
 JET = "0.9"
 LinearAlgebra = "1"
 SafeTestsets = "0.1"
@@ -36,5 +39,4 @@ TestExtras = "5ed8adda-3752-4e41-b88a-e8b09835ee3a"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["Aqua", "JET", "SafeTestsets", "Test", "TestExtras", "ChainRulesCore",
-        "ChainRulesTestUtils", "StableRNGs", "Zygote"]
+test = ["Aqua", "JET", "SafeTestsets", "Test", "TestExtras", "ChainRulesCore", "ChainRulesTestUtils", "StableRNGs", "Zygote"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MatrixAlgebraKit"
 uuid = "6c742aac-3347-4629-af66-fc926824e5e4"
 authors = ["Jutho <jutho.haegeman@ugent.be> and contributors"]
-version = "0.2.2"
+version = "0.2.3"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/ext/MatrixAlgebraKitFillArraysExt.jl
+++ b/ext/MatrixAlgebraKitFillArraysExt.jl
@@ -1,0 +1,71 @@
+module MatrixAlgebraKitFillArraysExt
+
+using MatrixAlgebraKit
+using MatrixAlgebraKit: AbstractAlgorithm
+using FillArrays
+
+struct EyeAlgorithm <: AbstractAlgorithm end
+
+for f in [:eig_full,
+          :eigh_full,
+          :qr_compact,
+          :qr_full,
+          :left_polar,
+          :lq_compact,
+          :lq_full,
+          :right_polar,
+          :svd_compact,
+          :svd_full]
+    @eval begin
+        MatrixAlgebraKit.copy_input(::typeof($f), a::Eye) = a
+    end
+end
+
+for f in [:eig, :eigh, :lq, :qr, :polar, :svd]
+    ff = Symbol("default_", f, "_algorithm")
+    @eval begin
+        function MatrixAlgebraKit.$ff(a::Type{<:Eye}; kwargs...)
+            return EyeAlgorithm()
+        end
+    end
+end
+
+for f in [:eig_full!,
+          :eigh_full!,
+          :qr_compact!,
+          :qr_full!,
+          :left_polar!,
+          :lq_compact!,
+          :lq_full!,
+          :right_polar!]
+    @eval begin
+        nfactors(::typeof($f)) = 2
+    end
+end
+for f in [:svd_compact!, :svd_full!]
+    @eval begin
+        nfactors(::typeof($f)) = 3
+    end
+end
+
+for f in [:eig_full!,
+          :eigh_full!,
+          :qr_compact!,
+          :qr_full!,
+          :left_polar!,
+          :lq_compact!,
+          :lq_full!,
+          :right_polar!,
+          :svd_compact!,
+          :svd_full!]
+    @eval begin
+        function MatrixAlgebraKit.initialize_output(::typeof($f), a::Eye, alg::EyeAlgorithm)
+            return ntuple(_ -> a, nfactors($f))
+        end
+        function MatrixAlgebraKit.$f(a::Eye, F, alg::EyeAlgorithm; kwargs...)
+            return ntuple(_ -> a, nfactors($f))
+        end
+    end
+end
+
+end

--- a/ext/MatrixAlgebraKitFillArraysExt.jl
+++ b/ext/MatrixAlgebraKitFillArraysExt.jl
@@ -179,7 +179,7 @@ end
 function MatrixAlgebraKit.left_polar!(A::AbstractZerosMatrix, F, alg::ZerosAlgorithm)
     check_input(left_polar!, A, F)
     U, S, Vᴴ = svd_compact(A)
-    return (Eye((axes(U, 1), axes(Vᴴ, 2))), Vᴴ' * S * Vᴴ)
+    return (Eye((axes(A, 1), axes(A, 2))), Vᴴ' * S * Vᴴ)
 end
 
 function MatrixAlgebraKit.check_input(::typeof(right_polar!), A::AbstractZerosMatrix, F)
@@ -368,6 +368,34 @@ end
 
 function MatrixAlgebraKit.svd_vals!(A::Eye, F, alg::EyeAlgorithm)
     return diagview(A)
+end
+
+function MatrixAlgebraKit.check_input(::typeof(left_polar!), A::Eye, F)
+    m, n = size(A)
+    m >= n ||
+        throw(ArgumentError("input matrix needs at least as many rows as columns"))
+    return nothing
+end
+function MatrixAlgebraKit.left_polar!(A::Eye, F, alg::EyeAlgorithm)
+    check_input(left_polar!, A, F)
+    return (Eye((axes(A, 1), axes(A, 2))), Eye((axes(A, 2), axes(A, 2))))
+end
+function MatrixAlgebraKit.left_polar!(A::SquareEye, F, alg::EyeAlgorithm)
+    return (A, A)
+end
+
+function MatrixAlgebraKit.check_input(::typeof(right_polar!), A::Eye, F)
+    m, n = size(A)
+    n >= m ||
+        throw(ArgumentError("input matrix needs at least as many columns as rows"))
+    return nothing
+end
+function MatrixAlgebraKit.right_polar!(A::Eye, F, alg::EyeAlgorithm)
+    check_input(right_polar!, A, F)
+    return (Eye((axes(A, 1), axes(A, 1))), Eye((axes(A, 1), axes(A, 2))))
+end
+function MatrixAlgebraKit.right_polar!(A::SquareEye, F, alg::EyeAlgorithm)
+    return (A, A)
 end
 
 end

--- a/ext/MatrixAlgebraKitFillArraysExt.jl
+++ b/ext/MatrixAlgebraKitFillArraysExt.jl
@@ -256,7 +256,7 @@ end
 
 function MatrixAlgebraKit.svd_full!(A::Eye, F, alg::EyeAlgorithm)
     ax = axes(A)
-    return (Eye((ax[1], ax[1])), A, Eye((ax[2], ax[2])))
+    return (Eye((ax[1],)), A, Eye((ax[2],)))
 end
 function MatrixAlgebraKit.svd_full!(A::SquareEye, F, alg::EyeAlgorithm)
     return (A, A, A)

--- a/ext/MatrixAlgebraKitFillArraysExt.jl
+++ b/ext/MatrixAlgebraKitFillArraysExt.jl
@@ -2,12 +2,20 @@ module MatrixAlgebraKitFillArraysExt
 
 using LinearAlgebra
 using MatrixAlgebraKit
-using MatrixAlgebraKit: AbstractAlgorithm
+using MatrixAlgebraKit: AbstractAlgorithm, check_input
 using FillArrays
 using FillArrays: AbstractZerosMatrix
 
-struct EyeAlgorithm <: AbstractAlgorithm end
 struct ZerosAlgorithm <: AbstractAlgorithm end
+
+for f in [:eig, :eigh, :lq, :qr, :svd]
+    ff = Symbol("default_", f, "_algorithm")
+    @eval begin
+        function MatrixAlgebraKit.$ff(::Type{<:AbstractZerosMatrix}; kwargs...)
+            return ZerosAlgorithm()
+        end
+    end
+end
 
 for f in [:eig_full,
           :eigh_full,
@@ -19,81 +27,181 @@ for f in [:eig_full,
           :right_polar,
           :svd_compact,
           :svd_full]
+    f! = Symbol(f, "!")
     @eval begin
-        MatrixAlgebraKit.copy_input(::typeof($f), a::Eye) = a
-
-        MatrixAlgebraKit.copy_input(::typeof($f), a::AbstractZerosMatrix) = a
-    end
-end
-
-for f in [:eig, :eigh, :lq, :qr, :polar, :svd]
-    ff = Symbol("default_", f, "_algorithm")
-    @eval begin
-        function MatrixAlgebraKit.$ff(a::Type{<:Eye}; kwargs...)
-            return EyeAlgorithm()
-        end
-
-        function MatrixAlgebraKit.$ff(a::Type{<:AbstractZerosMatrix}; kwargs...)
-            return ZerosAlgorithm()
-        end
-    end
-end
-
-for f in [:eig_full!,
-          :eigh_full!,
-          :qr_compact!,
-          :qr_full!,
-          :left_polar!,
-          :lq_compact!,
-          :lq_full!,
-          :right_polar!]
-    @eval begin
-        nfactors(::typeof($f)) = 2
-    end
-end
-for f in [:svd_compact!, :svd_full!]
-    @eval begin
-        nfactors(::typeof($f)) = 3
-    end
-end
-
-for f in [:eig_full!,
-          :eigh_full!,
-          :qr_compact!,
-          :qr_full!,
-          :left_polar!,
-          :lq_compact!,
-          :lq_full!,
-          :right_polar!,
-          :svd_compact!,
-          :svd_full!]
-    @eval begin
-        function MatrixAlgebraKit.initialize_output(::typeof($f), a::Eye,
-                                                    alg::EyeAlgorithm)
-            return nothing
-        end
-        function MatrixAlgebraKit.check_input(::typeof($f), A::Eye, F)
-            LinearAlgebra.checksquare(A)
-            return nothing
-        end
-
-        function MatrixAlgebraKit.$f(a::Eye, F, alg::EyeAlgorithm; kwargs...)
-            return ntuple(_ -> a, nfactors($f))
-        end
-
-        function MatrixAlgebraKit.initialize_output(::typeof($f), a::AbstractZerosMatrix,
+        MatrixAlgebraKit.copy_input(::typeof($f), A::AbstractZerosMatrix) = A
+        function MatrixAlgebraKit.initialize_output(::typeof($f!), A::AbstractZerosMatrix,
                                                     alg::ZerosAlgorithm)
             return nothing
         end
+    end
+end
+
+for f in [:eig_full!,
+          :eigh_full!]
+    @eval begin
         function MatrixAlgebraKit.check_input(::typeof($f), A::AbstractZerosMatrix, F)
             LinearAlgebra.checksquare(A)
             return nothing
         end
-        function MatrixAlgebraKit.$f(a::AbstractZerosMatrix, F, alg::ZerosAlgorithm;
+        function MatrixAlgebraKit.$f(A::AbstractZerosMatrix, F, alg::ZerosAlgorithm;
                                      kwargs...)
-            return ntuple(_ -> a, nfactors($f))
+            check_input($f, A, F)
+            return (A, Eye(axes(A)))
         end
     end
+end
+
+function MatrixAlgebraKit.qr_compact!(A::AbstractZerosMatrix, F, alg::ZerosAlgorithm)
+    m, n = size(A)
+    ax = axes(A)
+    if m > n
+        r_ax = (ax[2], ax[2])
+        return (Eye(ax), Zeros(r_ax))
+    else
+        q_ax = (ax[1], ax[1])
+        return (Eye(q_ax), Zeros(ax))
+    end
+end
+
+function MatrixAlgebraKit.qr_full!(A::AbstractZerosMatrix, F, alg::ZerosAlgorithm)
+    ax = axes(A)
+    q_ax = (ax[1], ax[1])
+    return (Eye(q_ax), Zeros(ax))
+end
+
+function MatrixAlgebraKit.lq_compact!(A::AbstractZerosMatrix, F, alg::ZerosAlgorithm)
+    m, n = size(A)
+    ax = axes(A)
+    if m < n
+        l_ax = (ax[1], ax[1])
+        return (Zeros(l_ax), Eye(ax))
+    else
+        q_ax = (ax[2], ax[2])
+        return (Zeros(ax), Eye(q_ax))
+    end
+end
+
+function MatrixAlgebraKit.lq_full!(A::AbstractZerosMatrix, F, alg::ZerosAlgorithm)
+    ax = axes(A)
+    q_ax = (ax[2], ax[2])
+    return (Zeros(ax), Eye(q_ax))
+end
+
+function MatrixAlgebraKit.svd_compact!(A::AbstractZerosMatrix, F, alg::ZerosAlgorithm)
+    m, n = size(A)
+    ax = axes(A)
+    if m > n
+        s_ax = (ax[2], ax[2])
+        return (Eye(ax), Zeros(s_ax), Eye(s_ax))
+    else
+        s_ax = (ax[1], ax[1])
+        return (Eye(s_ax), Zeros(s_ax), Eye(ax))
+    end
+end
+
+function MatrixAlgebraKit.svd_full!(A::AbstractZerosMatrix, F, alg::ZerosAlgorithm)
+    ax = axes(A)
+    return (Eye((ax[1], ax[1])), Zeros(ax), Eye((ax[2], ax[2])))
+end
+
+struct EyeAlgorithm <: AbstractAlgorithm end
+
+for f in [:eig, :eigh, :lq, :qr, :polar, :svd]
+    ff = Symbol("default_", f, "_algorithm")
+    @eval begin
+        function MatrixAlgebraKit.$ff(A::Type{<:Eye}; kwargs...)
+            return EyeAlgorithm()
+        end
+    end
+end
+
+for f in [:eig_full,
+          :eigh_full,
+          :qr_compact,
+          :qr_full,
+          :lq_compact,
+          :lq_full,
+          :left_polar,
+          :right_polar,
+          :svd_compact,
+          :svd_full]
+    f! = Symbol(f, "!")
+    @eval begin
+        MatrixAlgebraKit.copy_input(::typeof($f), A::Eye) = A
+        function MatrixAlgebraKit.initialize_output(::typeof($f!), A::Eye,
+                                                    alg::EyeAlgorithm)
+            return nothing
+        end
+    end
+end
+
+for f in [:eig_full!,
+          :eigh_full!]
+    @eval begin
+        function MatrixAlgebraKit.check_input(::typeof($f), A::Eye, F)
+            LinearAlgebra.checksquare(A)
+            return nothing
+        end
+        function MatrixAlgebraKit.$f(A::Eye, F, alg::EyeAlgorithm;
+                                     kwargs...)
+            check_input($f, A, F)
+            return (A, A)
+        end
+    end
+end
+
+function MatrixAlgebraKit.qr_compact!(A::Eye, F, alg::EyeAlgorithm)
+    m, n = size(A)
+    ax = axes(A)
+    if m > n
+        r_ax = (ax[2], ax[2])
+        return (Eye(ax), Eye(r_ax))
+    else
+        q_ax = (ax[1], ax[1])
+        return (Eye(q_ax), Eye(ax))
+    end
+end
+
+function MatrixAlgebraKit.qr_full!(A::Eye, F, alg::EyeAlgorithm)
+    ax = axes(A)
+    q_ax = (ax[1], ax[1])
+    return (Eye(q_ax), A)
+end
+
+function MatrixAlgebraKit.lq_compact!(A::Eye, F, alg::EyeAlgorithm)
+    m, n = size(A)
+    ax = axes(A)
+    if m < n
+        l_ax = (ax[1], ax[1])
+        return (Eye(l_ax), Eye(ax))
+    else
+        q_ax = (ax[2], ax[2])
+        return (Eye(ax), Eye(q_ax))
+    end
+end
+
+function MatrixAlgebraKit.lq_full!(A::Eye, F, alg::EyeAlgorithm)
+    ax = axes(A)
+    q_ax = (ax[2], ax[2])
+    return (A, Eye(q_ax))
+end
+
+function MatrixAlgebraKit.svd_compact!(A::Eye, F, alg::EyeAlgorithm)
+    m, n = size(A)
+    ax = axes(A)
+    if m > n
+        s_ax = (ax[2], ax[2])
+        return (Eye(ax), Eye(s_ax), Eye(s_ax))
+    else
+        s_ax = (ax[1], ax[1])
+        return (Eye(s_ax), Eye(s_ax), Eye(ax))
+    end
+end
+
+function MatrixAlgebraKit.svd_full!(A::Eye, F, alg::EyeAlgorithm)
+    ax = axes(A)
+    return (Eye((ax[1], ax[1])), A, Eye((ax[2], ax[2])))
 end
 
 end

--- a/ext/MatrixAlgebraKitFillArraysExt.jl
+++ b/ext/MatrixAlgebraKitFillArraysExt.jl
@@ -4,7 +4,11 @@ using LinearAlgebra
 using MatrixAlgebraKit
 using MatrixAlgebraKit: AbstractAlgorithm, check_input, diagview
 using FillArrays
-using FillArrays: AbstractZerosMatrix
+using FillArrays: AbstractZerosMatrix, OnesVector, RectDiagonal
+
+function MatrixAlgebraKit.diagview(A::RectDiagonal{<:Any,<:OnesVector})
+    return A.diag
+end
 
 struct ZerosAlgorithm <: AbstractAlgorithm end
 
@@ -63,7 +67,7 @@ for f in [:eig_vals!, :eigh_vals!]
         function MatrixAlgebraKit.$f(A::AbstractZerosMatrix, F, alg::ZerosAlgorithm;
                                      kwargs...)
             check_input($f, A, F)
-            return Zeros(axes(A, 1))
+            return diagview(A)
         end
     end
 end
@@ -119,6 +123,10 @@ end
 function MatrixAlgebraKit.svd_full!(A::AbstractZerosMatrix, F, alg::ZerosAlgorithm)
     ax = axes(A)
     return (Eye((ax[1], ax[1])), Zeros(ax), Eye((ax[2], ax[2])))
+end
+
+function MatrixAlgebraKit.svd_vals!(A::AbstractZerosMatrix, F, alg::ZerosAlgorithm)
+    return diagview(A)
 end
 
 struct EyeAlgorithm <: AbstractAlgorithm end
@@ -234,6 +242,10 @@ end
 function MatrixAlgebraKit.svd_full!(A::Eye, F, alg::EyeAlgorithm)
     ax = axes(A)
     return (Eye((ax[1], ax[1])), A, Eye((ax[2], ax[2])))
+end
+
+function MatrixAlgebraKit.svd_vals!(A::Eye, F, alg::EyeAlgorithm)
+    return diagview(A)
 end
 
 end

--- a/ext/MatrixAlgebraKitFillArraysExt.jl
+++ b/ext/MatrixAlgebraKitFillArraysExt.jl
@@ -14,7 +14,7 @@ end
 
 struct ZerosAlgorithm <: AbstractAlgorithm end
 
-for f in [:eig, :eigh, :lq, :qr, :svd]
+for f in [:eig, :eigh, :lq, :polar, :qr, :svd]
     ff = Symbol("default_", f, "_algorithm")
     @eval begin
         function MatrixAlgebraKit.$ff(::Type{<:AbstractZerosMatrix}; kwargs...)
@@ -168,6 +168,30 @@ end
 
 function MatrixAlgebraKit.svd_vals!(A::AbstractZerosMatrix, F, alg::ZerosAlgorithm)
     return diagview(A)
+end
+
+function MatrixAlgebraKit.check_input(::typeof(left_polar!), A::AbstractZerosMatrix, F)
+    m, n = size(A)
+    m >= n ||
+        throw(ArgumentError("input matrix needs at least as many rows as columns"))
+    return nothing
+end
+function MatrixAlgebraKit.left_polar!(A::AbstractZerosMatrix, F, alg::ZerosAlgorithm)
+    check_input(left_polar!, A, F)
+    U, S, Vᴴ = svd_compact(A)
+    return (Eye((axes(U, 1), axes(Vᴴ, 2))), Vᴴ' * S * Vᴴ)
+end
+
+function MatrixAlgebraKit.check_input(::typeof(right_polar!), A::AbstractZerosMatrix, F)
+    m, n = size(A)
+    n >= m ||
+        throw(ArgumentError("input matrix needs at least as many columns as rows"))
+    return nothing
+end
+function MatrixAlgebraKit.right_polar!(A::AbstractZerosMatrix, F, alg::ZerosAlgorithm)
+    check_input(right_polar!, A, F)
+    U, S, Vᴴ = svd_compact(A)
+    return (U * S * U', Eye((axes(U, 1), axes(Vᴴ, 2))))
 end
 
 struct EyeAlgorithm <: AbstractAlgorithm end

--- a/ext/MatrixAlgebraKitFillArraysExt.jl
+++ b/ext/MatrixAlgebraKitFillArraysExt.jl
@@ -4,7 +4,7 @@ using LinearAlgebra
 using MatrixAlgebraKit
 using MatrixAlgebraKit: AbstractAlgorithm, check_input, diagview
 using FillArrays
-using FillArrays: AbstractZerosMatrix, OnesVector, RectDiagonal
+using FillArrays: AbstractZerosMatrix, OnesVector, RectDiagonal, SquareEye
 
 function MatrixAlgebraKit.diagview(A::RectDiagonal{<:Any,<:OnesVector})
     return A.diag
@@ -202,11 +202,17 @@ function MatrixAlgebraKit.qr_compact!(A::Eye, F, alg::EyeAlgorithm)
         return (Eye(q_ax), Eye(ax))
     end
 end
+function MatrixAlgebraKit.qr_compact!(A::SquareEye, F, alg::EyeAlgorithm)
+    return (A, A)
+end
 
 function MatrixAlgebraKit.qr_full!(A::Eye, F, alg::EyeAlgorithm)
     ax = axes(A)
     q_ax = (ax[1], ax[1])
     return (Eye(q_ax), A)
+end
+function MatrixAlgebraKit.qr_full!(A::SquareEye, F, alg::EyeAlgorithm)
+    return (A, A)
 end
 
 function MatrixAlgebraKit.lq_compact!(A::Eye, F, alg::EyeAlgorithm)
@@ -220,11 +226,17 @@ function MatrixAlgebraKit.lq_compact!(A::Eye, F, alg::EyeAlgorithm)
         return (Eye(ax), Eye(q_ax))
     end
 end
+function MatrixAlgebraKit.lq_compact!(A::SquareEye, F, alg::EyeAlgorithm)
+    return (A, A)
+end
 
 function MatrixAlgebraKit.lq_full!(A::Eye, F, alg::EyeAlgorithm)
     ax = axes(A)
     q_ax = (ax[2], ax[2])
     return (A, Eye(q_ax))
+end
+function MatrixAlgebraKit.lq_full!(A::SquareEye, F, alg::EyeAlgorithm)
+    return (A, A)
 end
 
 function MatrixAlgebraKit.svd_compact!(A::Eye, F, alg::EyeAlgorithm)
@@ -238,10 +250,16 @@ function MatrixAlgebraKit.svd_compact!(A::Eye, F, alg::EyeAlgorithm)
         return (Eye(s_ax), Eye(s_ax), Eye(ax))
     end
 end
+function MatrixAlgebraKit.svd_compact!(A::SquareEye, F, alg::EyeAlgorithm)
+    return (A, A, A)
+end
 
 function MatrixAlgebraKit.svd_full!(A::Eye, F, alg::EyeAlgorithm)
     ax = axes(A)
     return (Eye((ax[1], ax[1])), A, Eye((ax[2], ax[2])))
+end
+function MatrixAlgebraKit.svd_full!(A::SquareEye, F, alg::EyeAlgorithm)
+    return (A, A, A)
 end
 
 function MatrixAlgebraKit.svd_vals!(A::Eye, F, alg::EyeAlgorithm)

--- a/ext/MatrixAlgebraKitFillArraysExt.jl
+++ b/ext/MatrixAlgebraKitFillArraysExt.jl
@@ -2,7 +2,7 @@ module MatrixAlgebraKitFillArraysExt
 
 using LinearAlgebra
 using MatrixAlgebraKit
-using MatrixAlgebraKit: AbstractAlgorithm, check_input
+using MatrixAlgebraKit: AbstractAlgorithm, check_input, diagview
 using FillArrays
 using FillArrays: AbstractZerosMatrix
 
@@ -19,6 +19,8 @@ end
 
 for f in [:eig_full,
           :eigh_full,
+          :eig_vals,
+          :eigh_vals,
           :qr_compact,
           :qr_full,
           :left_polar,
@@ -26,7 +28,8 @@ for f in [:eig_full,
           :lq_full,
           :right_polar,
           :svd_compact,
-          :svd_full]
+          :svd_full,
+          :svd_vals]
     f! = Symbol(f, "!")
     @eval begin
         MatrixAlgebraKit.copy_input(::typeof($f), A::AbstractZerosMatrix) = A
@@ -37,8 +40,7 @@ for f in [:eig_full,
     end
 end
 
-for f in [:eig_full!,
-          :eigh_full!]
+for f in [:eig_full!, :eigh_full!]
     @eval begin
         function MatrixAlgebraKit.check_input(::typeof($f), A::AbstractZerosMatrix, F)
             LinearAlgebra.checksquare(A)
@@ -48,6 +50,20 @@ for f in [:eig_full!,
                                      kwargs...)
             check_input($f, A, F)
             return (A, Eye(axes(A)))
+        end
+    end
+end
+
+for f in [:eig_vals!, :eigh_vals!]
+    @eval begin
+        function MatrixAlgebraKit.check_input(::typeof($f), A::AbstractZerosMatrix, F)
+            LinearAlgebra.checksquare(A)
+            return nothing
+        end
+        function MatrixAlgebraKit.$f(A::AbstractZerosMatrix, F, alg::ZerosAlgorithm;
+                                     kwargs...)
+            check_input($f, A, F)
+            return Zeros(axes(A, 1))
         end
     end
 end
@@ -118,6 +134,8 @@ end
 
 for f in [:eig_full,
           :eigh_full,
+          :eig_vals,
+          :eigh_vals,
           :qr_compact,
           :qr_full,
           :lq_compact,
@@ -125,7 +143,8 @@ for f in [:eig_full,
           :left_polar,
           :right_polar,
           :svd_compact,
-          :svd_full]
+          :svd_full,
+          :svd_vals]
     f! = Symbol(f, "!")
     @eval begin
         MatrixAlgebraKit.copy_input(::typeof($f), A::Eye) = A
@@ -136,8 +155,7 @@ for f in [:eig_full,
     end
 end
 
-for f in [:eig_full!,
-          :eigh_full!]
+for f in [:eig_full!, :eigh_full!]
     @eval begin
         function MatrixAlgebraKit.check_input(::typeof($f), A::Eye, F)
             LinearAlgebra.checksquare(A)
@@ -147,6 +165,20 @@ for f in [:eig_full!,
                                      kwargs...)
             check_input($f, A, F)
             return (A, A)
+        end
+    end
+end
+
+for f in [:eig_vals!, :eigh_vals!]
+    @eval begin
+        function MatrixAlgebraKit.check_input(::typeof($f), A::Eye, F)
+            LinearAlgebra.checksquare(A)
+            return nothing
+        end
+        function MatrixAlgebraKit.$f(A::Eye, F, alg::EyeAlgorithm;
+                                     kwargs...)
+            check_input($f, A, F)
+            return diagview(A)
         end
     end
 end

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -99,7 +99,6 @@ function select_algorithm(f::F, ::Type{A}, alg::Alg=nothing; kwargs...) where {F
     throw(ArgumentError("Unknown alg $alg"))
 end
 
-
 @doc """
     MatrixAlgebraKit.default_algorithm(f, A; kwargs...)
     MatrixAlgebraKit.default_algorithm(f, ::Type{TA}; kwargs...) where {TA}

--- a/test/fillarrays.jl
+++ b/test/fillarrays.jl
@@ -64,15 +64,15 @@ using FillArrays: SquareEye
     @test iszero(R)
     @test R isa Zeros
 
-    # A = Zeros(4, 3)
-    # Q, R = @constinferred left_polar(A)
-    # @test Q * R == A
-    # @test size(Q) == (4, 3)
-    # @test size(R) == (3, 3)
-    # @test Q == Matrix(I, (4, 3))
-    # @test Q isa Eye
-    # @test iszero(R)
-    # @test R isa Zeros
+    A = Zeros(4, 3)
+    Q, R = @constinferred left_polar(A)
+    @test Q * R == A
+    @test size(Q) == (4, 3)
+    @test size(R) == (3, 3)
+    @test Q == Matrix(I, (4, 3))
+    @test Q isa Eye
+    @test iszero(R)
+    @test R isa Zeros
 
     A = Zeros(3, 4)
     L, Q = @constinferred lq_compact(A)
@@ -109,15 +109,15 @@ using FillArrays: SquareEye
     @test Q == Eye(4)
     @test Q isa Eye
 
-    # A = Zeros(3, 4)
-    # L, Q = @constinferred right_polar(A)
-    # @test L * Q == A
-    # @test size(L) == (3, 3)
-    # @test size(Q) == (3, 4)
-    # @test iszero(L)
-    # @test L isa Zeros
-    # @test Q == Matrix(I, (3, 4))
-    # @test Q isa Eye
+    A = Zeros(3, 4)
+    L, Q = @constinferred right_polar(A)
+    @test L * Q == A
+    @test size(L) == (3, 3)
+    @test size(Q) == (3, 4)
+    @test iszero(L)
+    @test L isa Zeros
+    @test Q == Matrix(I, (3, 4))
+    @test Q isa Eye
 
     A = Zeros(3, 4)
     U, S, V = @constinferred svd_compact(A)

--- a/test/fillarrays.jl
+++ b/test/fillarrays.jl
@@ -102,6 +102,12 @@ using FillArrays
     @test U isa Eye
     @test V == I
     @test V isa Eye
+
+    A = Zeros(3, 4)
+    D = @constinferred svd_vals(A)
+    @test size(D) == (minimum(size(A)),)
+    @test iszero(D)
+    @test D isa Zeros
 end
 
 @testset "Eye" begin
@@ -202,4 +208,10 @@ end
     @test U isa Eye
     @test V == I
     @test V isa Eye
+
+    A = Eye(3, 4)
+    D = @constinferred svd_vals(A)
+    @test size(D) == (minimum(size(A)),)
+    @test all(isone, D)
+    @test D isa Ones
 end

--- a/test/fillarrays.jl
+++ b/test/fillarrays.jl
@@ -39,12 +39,6 @@ using FillArrays
     # @test iszero(R)
     # @test R isa Zeros
 
-    # A = Zeros(3)
-    # Q, R = @constinferred qr_compact(A)
-    # @test Q * R == A
-    # @test Q === A
-    # @test R === A
-
     # A = Zeros(4, 3)
     # Q, R = @constinferred qr_full(A)
     # @test Q * R == A
@@ -55,12 +49,6 @@ using FillArrays
     # @test iszero(R)
     # @test R isa Zeros
 
-    # A = Zeros(3)
-    # Q, R = @constinferred qr_full(A)
-    # @test Q * R == A
-    # @test Q === A
-    # @test R === A
-
     # A = Zeros(4, 3)
     # Q, R = @constinferred left_polar(A)
     # @test Q * R == A
@@ -70,12 +58,6 @@ using FillArrays
     # @test Q isa Eye
     # @test iszero(R)
     # @test R isa Zeros
-
-    # A = Zeros(3)
-    # Q, R = @constinferred left_polar(A)
-    # @test Q * R == A
-    # @test Q === A
-    # @test R === A
 
     A = Zeros(3, 4)
     L, Q = @constinferred lq_compact(A)
@@ -121,12 +103,6 @@ using FillArrays
     # @test L isa Zeros
     # @test Q == Matrix(I, (3, 4))
     # @test Q isa Eye
-
-    # A = Zeros(3, 4)
-    # L, Q = @constinferred right_polar(A)
-    # @test L * Q == A
-    # @test L === A
-    # @test Q === A
 
     A = Zeros(3, 4)
     U, S, V = @constinferred svd_compact(A)
@@ -220,6 +196,22 @@ end
     # @test Q === A
     # @test R === A
 
+    # A = Eye(4, 3)
+    # Q, R = @constinferred left_polar(A)
+    # @test Q * R == A
+    # @test size(Q) == (4, 3)
+    # @test size(R) == (3, 3)
+    # @test Q == Matrix(I, (4, 3))
+    # @test Q isa Eye
+    # @test R == I
+    # @test R isa Eye
+
+    # A = Eye(3)
+    # Q, R = @constinferred left_polar(A)
+    # @test Q * R == A
+    # @test Q === A
+    # @test R === A
+
     A = Eye(3, 4)
     L, Q = @constinferred lq_compact(A)
     @test L * Q == A
@@ -251,6 +243,22 @@ end
     @test L * Q == A
     @test L === A
     @test Q === A
+
+    # A = Eye(3, 4)
+    # L, Q = @constinferred right_polar(A)
+    # @test L * Q == A
+    # @test size(L) == (3, 3)
+    # @test size(Q) == (3, 4)
+    # @test L == I
+    # @test L isa Eye
+    # @test Q == Matrix(I, (3, 4))
+    # @test Q isa Eye
+
+    # A = Eye(3)
+    # L, Q = @constinferred right_polar(A)
+    # @test L * Q == A
+    # @test L === A
+    # @test Q === A
 
     A = Eye(3, 4)
     U, S, V = @constinferred svd_compact(A)

--- a/test/fillarrays.jl
+++ b/test/fillarrays.jl
@@ -6,10 +6,10 @@ using FillArrays
 @testset "Eye" begin
     for f in [:eig_full!,
               :eigh_full!,
-              # TODO: Reenable once https://github.com/QuantumKitHub/MatrixAlgebraKit.jl/pull/32
-              # is merged.
-              # :qr_compact!,
-              # :qr_full!,
+     # TODO: Reenable once https://github.com/QuantumKitHub/MatrixAlgebraKit.jl/pull/32
+     # is merged.
+     # :qr_compact!,
+     # :qr_full!,
               :left_polar!,
               :lq_compact!,
               :lq_full!,
@@ -18,6 +18,11 @@ using FillArrays
               :svd_full!]
         @eval begin
             A = Eye(3)
+            F = @constinferred $f(A)
+            @test A === prod(F)
+            @test all(x -> x === A, F)
+
+            A = Zeros(3, 3)
             F = @constinferred $f(A)
             @test A === prod(F)
             @test all(x -> x === A, F)

--- a/test/fillarrays.jl
+++ b/test/fillarrays.jl
@@ -76,19 +76,9 @@ using FillArrays: SquareEye
     @test iszero(R)
     @test R isa Zeros
 
-    A = Zeros(3, 4)
-    L, Q = @constinferred lq_compact(A)
-    @test L * Q == A
-    @test size(L) == (3, 3)
-    @test size(Q) == (3, 4)
-    @test iszero(L)
-    @test L isa Zeros
-    @test Q == Matrix(I, (3, 4))
-    @test Q isa Eye
-
     for f in (lq_compact, right_orth)
         A = Zeros(3, 4)
-        L, Q = @constinferred lq_compact(A)
+        L, Q = @constinferred f(A)
         @test L * Q == A
         @test L == Zeros(3, 3)
         @test L isa Zeros
@@ -211,69 +201,73 @@ end
         end
     end
 
-    # A = Eye(4, 3)
-    # Q, R = @constinferred qr_compact(A)
-    # @test Q * R == A
-    # @test size(Q) == (4, 3)
-    # @test size(R) == (3, 3)
-    # @test Q == Matrix(I, (4, 3))
-    # @test Q isa Eye
-    # @test R == I
-    # @test R isa Eye
+    for f in (qr_compact, left_orth)
+        A = Eye(4, 3)
+        Q, R = @constinferred f(A)
+        @test Q * R == A
+        @test size(Q) == (4, 3)
+        @test size(R) == (3, 3)
+        @test Q == Matrix(I, (4, 3))
+        @test Q isa Eye
+        @test R == I
+        @test R isa Eye
 
-    # A = Eye(3)
-    # Q, R = @constinferred qr_compact(A)
-    # @test Q * R == A
-    # @test Q === A
-    # @test R === A
+        A = Eye(3)
+        Q, R = @constinferred f(A)
+        @test Q * R == A
+        @test Q === A
+        @test R === A
+    end
 
-    # A = Eye(4, 3)
-    # Q, R = @constinferred qr_full(A)
-    # @test Q * R == A
-    # @test size(Q) == (4, 4)
-    # @test size(R) == (4, 3)
-    # @test Q == I
-    # @test Q isa Eye
-    # @test R == I
-    # @test R isa Eye
-
-    # A = Eye(3)
-    # Q, R = @constinferred qr_full(A)
-    # @test Q * R == A
-    # @test Q === A
-    # @test R === A
-
-    # A = Eye(4, 3)
-    # Q, R = @constinferred left_polar(A)
-    # @test Q * R == A
-    # @test size(Q) == (4, 3)
-    # @test size(R) == (3, 3)
-    # @test Q == Matrix(I, (4, 3))
-    # @test Q isa Eye
-    # @test R == I
-    # @test R isa Eye
-
-    # A = Eye(3)
-    # Q, R = @constinferred left_polar(A)
-    # @test Q * R == A
-    # @test Q === A
-    # @test R === A
-
-    A = Eye(3, 4)
-    L, Q = @constinferred lq_compact(A)
-    @test L * Q == A
-    @test size(L) == (3, 3)
-    @test size(Q) == (3, 4)
-    @test L == I
-    @test L isa Eye
-    @test Q == Matrix(I, (3, 4))
+    A = Eye(4, 3)
+    Q, R = @constinferred qr_full(A)
+    @test Q * R == A
+    @test size(Q) == (4, 4)
+    @test size(R) == (4, 3)
+    @test Q == I
     @test Q isa Eye
+    @test R == Eye(4, 3)
+    @test R isa Eye
 
     A = Eye(3)
-    L, Q = @constinferred lq_compact(A)
-    @test L * Q == A
-    @test L === A
+    Q, R = @constinferred qr_full(A)
+    @test Q * R == A
     @test Q === A
+    @test R === A
+
+    A = Eye(4, 3)
+    Q, R = @constinferred left_polar(A)
+    @test Q * R == A
+    @test size(Q) == (4, 3)
+    @test size(R) == (3, 3)
+    @test Q == Matrix(I, (4, 3))
+    @test Q isa Eye
+    @test R == I
+    @test R isa Eye
+
+    A = Eye(3)
+    Q, R = @constinferred left_polar(A)
+    @test Q * R == A
+    @test Q === A
+    @test R === A
+
+    for f in (lq_compact, right_orth)
+        A = Eye(3, 4)
+        L, Q = @constinferred lq_compact(A)
+        @test L * Q == A
+        @test size(L) == (3, 3)
+        @test size(Q) == (3, 4)
+        @test L == I
+        @test L isa Eye
+        @test Q == Matrix(I, (3, 4))
+        @test Q isa Eye
+
+        A = Eye(3)
+        L, Q = @constinferred lq_compact(A)
+        @test L * Q == A
+        @test L === A
+        @test Q === A
+    end
 
     A = Eye(3, 4)
     L, Q = @constinferred lq_full(A)
@@ -291,21 +285,21 @@ end
     @test L === A
     @test Q === A
 
-    # A = Eye(3, 4)
-    # L, Q = @constinferred right_polar(A)
-    # @test L * Q == A
-    # @test size(L) == (3, 3)
-    # @test size(Q) == (3, 4)
-    # @test L == I
-    # @test L isa Eye
-    # @test Q == Matrix(I, (3, 4))
-    # @test Q isa Eye
+    A = Eye(3, 4)
+    L, Q = @constinferred right_polar(A)
+    @test L * Q == A
+    @test size(L) == (3, 3)
+    @test size(Q) == (3, 4)
+    @test L == I
+    @test L isa Eye
+    @test Q == Matrix(I, (3, 4))
+    @test Q isa Eye
 
-    # A = Eye(3)
-    # L, Q = @constinferred right_polar(A)
-    # @test L * Q == A
-    # @test L === A
-    # @test Q === A
+    A = Eye(3)
+    L, Q = @constinferred right_polar(A)
+    @test L * Q == A
+    @test L === A
+    @test Q === A
 
     A = Eye(3, 4)
     U, S, V = @constinferred svd_compact(A)

--- a/test/fillarrays.jl
+++ b/test/fillarrays.jl
@@ -44,15 +44,17 @@ using FillArrays: SquareEye
         end
     end
 
-    A = Zeros(4, 3)
-    Q, R = @constinferred qr_compact(A)
-    @test Q * R == A
-    @test size(Q) == (4, 3)
-    @test size(R) == (3, 3)
-    @test Q == Matrix(I, (4, 3))
-    @test Q isa Eye
-    @test iszero(R)
-    @test R isa Zeros
+    for f in (qr_compact, left_orth)
+        A = Zeros(4, 3)
+        Q, R = @constinferred f(A)
+        @test Q * R == A
+        @test size(Q) == (4, 3)
+        @test size(R) == (3, 3)
+        @test Q == Matrix(I, (4, 3))
+        @test Q isa Eye
+        @test iszero(R)
+        @test R isa Zeros
+    end
 
     A = Zeros(4, 3)
     Q, R = @constinferred qr_full(A)
@@ -84,13 +86,15 @@ using FillArrays: SquareEye
     @test Q == Matrix(I, (3, 4))
     @test Q isa Eye
 
-    A = Zeros(3, 4)
-    L, Q = @constinferred lq_compact(A)
-    @test L * Q == A
-    @test L == Zeros(3, 3)
-    @test L isa Zeros
-    @test Q == Eye(3, 4)
-    @test Q isa Eye
+    for f in (lq_compact, right_orth)
+        A = Zeros(3, 4)
+        L, Q = @constinferred lq_compact(A)
+        @test L * Q == A
+        @test L == Zeros(3, 3)
+        @test L isa Zeros
+        @test Q == Eye(3, 4)
+        @test Q isa Eye
+    end
 
     A = Zeros(3, 4)
     L, Q = @constinferred lq_full(A)

--- a/test/fillarrays.jl
+++ b/test/fillarrays.jl
@@ -1,31 +1,185 @@
 using MatrixAlgebraKit
+using LinearAlgebra
 using Test
 using TestExtras
 using FillArrays
 
-@testset "Eye" begin
-    for f in [:eig_full!,
-              :eigh_full!,
-     # TODO: Reenable once https://github.com/QuantumKitHub/MatrixAlgebraKit.jl/pull/32
-     # is merged.
-     # :qr_compact!,
-     # :qr_full!,
-              :left_polar!,
-              :lq_compact!,
-              :lq_full!,
-              :right_polar!,
-              :svd_compact!,
-              :svd_full!]
+@testset "Zeros" begin
+    for f in [:eig_full, :eigh_full]
         @eval begin
-            A = Eye(3)
-            F = @constinferred $f(A)
-            @test A === prod(F)
-            @test all(x -> x === A, F)
-
             A = Zeros(3, 3)
-            F = @constinferred $f(A)
-            @test A === prod(F)
-            @test all(x -> x === A, F)
+            D, V = @constinferred $f(A)
+            @test A * V == D * V
+            @test size(D) == size(A)
+            @test size(V) == size(A)
+            @test iszero(D)
+            @test D isa Zeros
+            @test V == I
+            @test V isa Eye
         end
     end
+
+    # for f in [:qr_compact, :left_polar]
+    #     @eval begin
+    #         A = Zeros(4, 3)
+    #         Q, R = @constinferred $f(A)
+    #         @test A == Q * R
+    #         @test size(Q) == (4, 3)
+    #         @test size(R) == (3, 3)
+    #         @test Q == Matrix(I, (4, 3))
+    #         @test Q isa Eye
+    #         @test iszero(R)
+    #         @test R isa Zeros
+    #     end
+    # end
+
+    # A = Zeros(4, 3)
+    # Q, R = @constinferred qr_full(A)
+    # @test A == Q * R
+    # @test size(Q) == (4, 4)
+    # @test size(R) == (4, 3)
+    # @test Q == I
+    # @test Q isa Eye
+    # @test iszero(R)
+    # @test R isa Zeros
+
+    for f in [:lq_compact] # :right_polar]
+        @eval begin
+            A = Zeros(3, 4)
+            L, Q = @constinferred $f(A)
+            @test A == L * Q
+            @test size(L) == (3, 3)
+            @test size(Q) == (3, 4)
+            @test iszero(L)
+            @test L isa Zeros
+            @test Q == Matrix(I, (3, 4))
+            @test Q isa Eye
+        end
+    end
+
+    A = Zeros(3, 4)
+    L, Q = @constinferred lq_full(A)
+    @test A == L * Q
+    @test size(L) == (3, 4)
+    @test size(Q) == (4, 4)
+    @test iszero(L)
+    @test L isa Zeros
+    @test Q == I
+    @test Q isa Eye
+
+    A = Zeros(3, 4)
+    U, S, V = @constinferred svd_compact(A)
+    @test U * S * V == A
+    @test size(U) == (3, 3)
+    @test size(S) == (3, 3)
+    @test size(V) == (3, 4)
+    @test iszero(S)
+    @test S isa Zeros
+    @test U == I
+    @test U isa Eye
+    @test V == Matrix(I, (3, 4))
+    @test V isa Eye
+
+    A = Zeros(3, 4)
+    U, S, V = @constinferred svd_full(A)
+    @test U * S * V == A
+    @test size(U) == (3, 3)
+    @test size(S) == (3, 4)
+    @test size(V) == (4, 4)
+    @test iszero(S)
+    @test S isa Zeros
+    @test U == I
+    @test U isa Eye
+    @test V == I
+    @test V isa Eye
+end
+
+@testset "Eye" begin
+    for f in [:eig_full, :eigh_full]
+        @eval begin
+            A = Eye(3, 3)
+            D, V = @constinferred $f(A)
+            @test A * V == D * V
+            @test size(D) == size(A)
+            @test size(V) == size(A)
+            @test V == I
+            @test D isa Eye
+            @test V == I
+            @test V isa Eye
+        end
+    end
+
+    # for f in [:qr_compact, :left_polar]
+    #     @eval begin
+    #         A = Eye(4, 3)
+    #         Q, R = @constinferred $f(A)
+    #         @test A == Q * R
+    #         @test size(Q) == (4, 3)
+    #         @test size(R) == (3, 3)
+    #         @test Q == Matrix(I, (4, 3))
+    #         @test Q isa Eye
+    #         @test R == I
+    #         @test R isa Eye
+    #     end
+    # end
+
+    # A = Eye(4, 3)
+    # Q, R = @constinferred qr_full(A)
+    # @test A == Q * R
+    # @test size(Q) == (4, 4)
+    # @test size(R) == (4, 3)
+    # @test Q == I
+    # @test Q isa Eye
+    # @test R == I
+    # @test R isa Eye
+
+    for f in [:lq_compact] # :right_polar]
+        @eval begin
+            A = Eye(3, 4)
+            L, Q = @constinferred $f(A)
+            @test A == L * Q
+            @test size(L) == (3, 3)
+            @test size(Q) == (3, 4)
+            @test L == I
+            @test L isa Eye
+            @test Q == Matrix(I, (3, 4))
+            @test Q isa Eye
+        end
+    end
+
+    A = Eye(3, 4)
+    L, Q = @constinferred lq_full(A)
+    @test A == L * Q
+    @test size(L) == (3, 4)
+    @test size(Q) == (4, 4)
+    @test L == Matrix(I, (3, 4))
+    @test L isa Eye
+    @test Q == I
+    @test Q isa Eye
+
+    A = Eye(3, 4)
+    U, S, V = @constinferred svd_compact(A)
+    @test U * S * V == A
+    @test size(U) == (3, 3)
+    @test size(S) == (3, 3)
+    @test size(V) == (3, 4)
+    @test S == I
+    @test S isa Eye
+    @test U == I
+    @test U isa Eye
+    @test V == Matrix(I, (3, 4))
+    @test V isa Eye
+
+    A = Eye(3, 4)
+    U, S, V = @constinferred svd_full(A)
+    @test U * S * V == A
+    @test size(U) == (3, 3)
+    @test size(S) == (3, 4)
+    @test size(V) == (4, 4)
+    @test S == Matrix(I, (3, 4))
+    @test S isa Eye
+    @test U == I
+    @test U isa Eye
+    @test V == I
+    @test V isa Eye
 end

--- a/test/fillarrays.jl
+++ b/test/fillarrays.jl
@@ -1,0 +1,26 @@
+using MatrixAlgebraKit
+using Test
+using TestExtras
+using FillArrays
+
+@testset "Eye" begin
+    for f in [:eig_full!,
+              :eigh_full!,
+              # TODO: Reenable once https://github.com/QuantumKitHub/MatrixAlgebraKit.jl/pull/32
+              # is merged.
+              # :qr_compact!,
+              # :qr_full!,
+              :left_polar!,
+              :lq_compact!,
+              :lq_full!,
+              :right_polar!,
+              :svd_compact!,
+              :svd_full!]
+        @eval begin
+            A = Eye(3)
+            F = @constinferred $f(A)
+            @test A === prod(F)
+            @test all(x -> x === A, F)
+        end
+    end
+end

--- a/test/fillarrays.jl
+++ b/test/fillarrays.jl
@@ -29,23 +29,25 @@ using FillArrays
         end
     end
 
-    # for f in [:qr_compact, :left_polar]
-    #     @eval begin
-    #         A = Zeros(4, 3)
-    #         Q, R = @constinferred $f(A)
-    #         @test A == Q * R
-    #         @test size(Q) == (4, 3)
-    #         @test size(R) == (3, 3)
-    #         @test Q == Matrix(I, (4, 3))
-    #         @test Q isa Eye
-    #         @test iszero(R)
-    #         @test R isa Zeros
-    #     end
-    # end
+    # A = Zeros(4, 3)
+    # Q, R = @constinferred qr_compact(A)
+    # @test Q * R == A
+    # @test size(Q) == (4, 3)
+    # @test size(R) == (3, 3)
+    # @test Q == Matrix(I, (4, 3))
+    # @test Q isa Eye
+    # @test iszero(R)
+    # @test R isa Zeros
+
+    # A = Zeros(3)
+    # Q, R = @constinferred qr_compact(A)
+    # @test Q * R == A
+    # @test Q === A
+    # @test R === A
 
     # A = Zeros(4, 3)
     # Q, R = @constinferred qr_full(A)
-    # @test A == Q * R
+    # @test Q * R == A
     # @test size(Q) == (4, 4)
     # @test size(R) == (4, 3)
     # @test Q == I
@@ -53,29 +55,78 @@ using FillArrays
     # @test iszero(R)
     # @test R isa Zeros
 
-    for f in [:lq_compact] # :right_polar]
-        @eval begin
-            A = Zeros(3, 4)
-            L, Q = @constinferred $f(A)
-            @test A == L * Q
-            @test size(L) == (3, 3)
-            @test size(Q) == (3, 4)
-            @test iszero(L)
-            @test L isa Zeros
-            @test Q == Matrix(I, (3, 4))
-            @test Q isa Eye
-        end
-    end
+    # A = Zeros(3)
+    # Q, R = @constinferred qr_full(A)
+    # @test Q * R == A
+    # @test Q === A
+    # @test R === A
+
+    # A = Zeros(4, 3)
+    # Q, R = @constinferred left_polar(A)
+    # @test Q * R == A
+    # @test size(Q) == (4, 3)
+    # @test size(R) == (3, 3)
+    # @test Q == Matrix(I, (4, 3))
+    # @test Q isa Eye
+    # @test iszero(R)
+    # @test R isa Zeros
+
+    # A = Zeros(3)
+    # Q, R = @constinferred left_polar(A)
+    # @test Q * R == A
+    # @test Q === A
+    # @test R === A
+
+    A = Zeros(3, 4)
+    L, Q = @constinferred lq_compact(A)
+    @test L * Q == A
+    @test size(L) == (3, 3)
+    @test size(Q) == (3, 4)
+    @test iszero(L)
+    @test L isa Zeros
+    @test Q == Matrix(I, (3, 4))
+    @test Q isa Eye
+
+    A = Zeros(3, 4)
+    L, Q = @constinferred lq_compact(A)
+    @test L * Q == A
+    @test L == Zeros(3, 3)
+    @test L isa Zeros
+    @test Q == Eye(3, 4)
+    @test Q isa Eye
 
     A = Zeros(3, 4)
     L, Q = @constinferred lq_full(A)
-    @test A == L * Q
+    @test L * Q == A
     @test size(L) == (3, 4)
     @test size(Q) == (4, 4)
     @test iszero(L)
     @test L isa Zeros
     @test Q == I
     @test Q isa Eye
+
+    A = Zeros(3, 4)
+    L, Q = @constinferred lq_full(A)
+    @test L * Q == A
+    @test L === A
+    @test Q == Eye(4)
+    @test Q isa Eye
+
+    # A = Zeros(3, 4)
+    # L, Q = @constinferred right_polar(A)
+    # @test L * Q == A
+    # @test size(L) == (3, 3)
+    # @test size(Q) == (3, 4)
+    # @test iszero(L)
+    # @test L isa Zeros
+    # @test Q == Matrix(I, (3, 4))
+    # @test Q isa Eye
+
+    # A = Zeros(3, 4)
+    # L, Q = @constinferred right_polar(A)
+    # @test L * Q == A
+    # @test L === A
+    # @test Q === A
 
     A = Zeros(3, 4)
     U, S, V = @constinferred svd_compact(A)
@@ -113,45 +164,49 @@ end
 @testset "Eye" begin
     for f in [:eig_full, :eigh_full]
         @eval begin
-            A = Eye(3, 3)
-            D, V = @constinferred $f(A)
-            @test A * V == D * V
-            @test size(D) == size(A)
-            @test size(V) == size(A)
-            @test V == I
-            @test D isa Eye
-            @test V == I
-            @test V isa Eye
+            for A in (Eye(3), Eye(3, 3))
+                local D, V = @constinferred $f(A)
+                @test A * V == D * V
+                @test size(D) == size(A)
+                @test size(V) == size(A)
+                @test V == I
+                @test typeof(D) === typeof(A)
+                @test V == I
+                @test typeof(V) === typeof(A)
+            end
         end
     end
 
     for f in [:eig_vals, :eigh_vals]
         @eval begin
-            A = Eye(3, 3)
-            D = @constinferred $f(A)
-            @test size(D) == (size(A, 1),)
-            @test all(isone, D)
-            @test D isa Ones
+            for A in (Eye(3), Eye(3, 3))
+                local D = @constinferred $f(A)
+                @test size(D) == (size(A, 1),)
+                @test all(isone, D)
+                @test D isa Ones
+            end
         end
     end
 
-    # for f in [:qr_compact, :left_polar]
-    #     @eval begin
-    #         A = Eye(4, 3)
-    #         Q, R = @constinferred $f(A)
-    #         @test A == Q * R
-    #         @test size(Q) == (4, 3)
-    #         @test size(R) == (3, 3)
-    #         @test Q == Matrix(I, (4, 3))
-    #         @test Q isa Eye
-    #         @test R == I
-    #         @test R isa Eye
-    #     end
-    # end
+    # A = Eye(4, 3)
+    # Q, R = @constinferred qr_compact(A)
+    # @test Q * R == A
+    # @test size(Q) == (4, 3)
+    # @test size(R) == (3, 3)
+    # @test Q == Matrix(I, (4, 3))
+    # @test Q isa Eye
+    # @test R == I
+    # @test R isa Eye
+
+    # A = Eye(3)
+    # Q, R = @constinferred qr_compact(A)
+    # @test Q * R == A
+    # @test Q === A
+    # @test R === A
 
     # A = Eye(4, 3)
     # Q, R = @constinferred qr_full(A)
-    # @test A == Q * R
+    # @test Q * R == A
     # @test size(Q) == (4, 4)
     # @test size(R) == (4, 3)
     # @test Q == I
@@ -159,29 +214,43 @@ end
     # @test R == I
     # @test R isa Eye
 
-    for f in [:lq_compact] # :right_polar]
-        @eval begin
-            A = Eye(3, 4)
-            L, Q = @constinferred $f(A)
-            @test A == L * Q
-            @test size(L) == (3, 3)
-            @test size(Q) == (3, 4)
-            @test L == I
-            @test L isa Eye
-            @test Q == Matrix(I, (3, 4))
-            @test Q isa Eye
-        end
-    end
+    # A = Eye(3)
+    # Q, R = @constinferred qr_full(A)
+    # @test Q * R == A
+    # @test Q === A
+    # @test R === A
+
+    A = Eye(3, 4)
+    L, Q = @constinferred lq_compact(A)
+    @test L * Q == A
+    @test size(L) == (3, 3)
+    @test size(Q) == (3, 4)
+    @test L == I
+    @test L isa Eye
+    @test Q == Matrix(I, (3, 4))
+    @test Q isa Eye
+
+    A = Eye(3)
+    L, Q = @constinferred lq_compact(A)
+    @test L * Q == A
+    @test L === A
+    @test Q === A
 
     A = Eye(3, 4)
     L, Q = @constinferred lq_full(A)
-    @test A == L * Q
+    @test L * Q == A
     @test size(L) == (3, 4)
     @test size(Q) == (4, 4)
     @test L == Matrix(I, (3, 4))
     @test L isa Eye
     @test Q == I
     @test Q isa Eye
+
+    A = Eye(3)
+    L, Q = @constinferred lq_full(A)
+    @test L * Q == A
+    @test L === A
+    @test Q === A
 
     A = Eye(3, 4)
     U, S, V = @constinferred svd_compact(A)
@@ -196,6 +265,13 @@ end
     @test V == Matrix(I, (3, 4))
     @test V isa Eye
 
+    A = Eye(3)
+    U, S, V = @constinferred svd_compact(A)
+    @test U * S * V == A
+    @test U === A
+    @test S === A
+    @test V === A
+
     A = Eye(3, 4)
     U, S, V = @constinferred svd_full(A)
     @test U * S * V == A
@@ -208,6 +284,13 @@ end
     @test U isa Eye
     @test V == I
     @test V isa Eye
+
+    A = Eye(3)
+    U, S, V = @constinferred svd_full(A)
+    @test U * S * V == A
+    @test U === A
+    @test S === A
+    @test V === A
 
     A = Eye(3, 4)
     D = @constinferred svd_vals(A)

--- a/test/fillarrays.jl
+++ b/test/fillarrays.jl
@@ -20,6 +20,20 @@ using FillArrays: SquareEye
         end
     end
 
+    for f in [:eig_trunc, :eigh_trunc]
+        @eval begin
+            A = Zeros(3, 3)
+            D, V = @constinferred $f(A; trunc=(; maxrank=2))
+            @test A * V == V * D
+            @test size(D) == (2, 2)
+            @test size(V) == (3, 2)
+            @test D == Zeros(2, 2)
+            @test D isa Zeros
+            @test V == Eye(3, 2)
+            @test V isa Eye
+        end
+    end
+
     for f in [:eig_vals, :eigh_vals]
         @eval begin
             A = Zeros(3, 3)
@@ -129,6 +143,19 @@ using FillArrays: SquareEye
     @test U == I
     @test U isa Eye
     @test V == I
+    @test V isa Eye
+
+    A = Zeros(3, 4)
+    U, S, V = @constinferred svd_trunc(A; trunc=(; maxrank=2))
+    @test U * S * V == Eye(3, 2) * Zeros(2, 2) * Eye(2, 4)
+    @test size(U) == (3, 2)
+    @test size(S) == (2, 2)
+    @test size(V) == (2, 4)
+    @test S == Zeros(2, 2)
+    @test S isa Zeros
+    @test U == Eye(3, 2)
+    @test U isa Eye
+    @test V == Eye(2, 4)
     @test V isa Eye
 
     A = Zeros(3, 4)

--- a/test/fillarrays.jl
+++ b/test/fillarrays.jl
@@ -19,6 +19,16 @@ using FillArrays
         end
     end
 
+    for f in [:eig_vals, :eigh_vals]
+        @eval begin
+            A = Zeros(3, 3)
+            D = @constinferred $f(A)
+            @test size(D) == (size(A, 1),)
+            @test iszero(D)
+            @test D isa Zeros
+        end
+    end
+
     # for f in [:qr_compact, :left_polar]
     #     @eval begin
     #         A = Zeros(4, 3)
@@ -106,6 +116,16 @@ end
             @test D isa Eye
             @test V == I
             @test V isa Eye
+        end
+    end
+
+    for f in [:eig_vals, :eigh_vals]
+        @eval begin
+            A = Eye(3, 3)
+            D = @constinferred $f(A)
+            @test size(D) == (size(A, 1),)
+            @test all(isone, D)
+            @test D isa Ones
         end
     end
 

--- a/test/fillarrays.jl
+++ b/test/fillarrays.jl
@@ -44,25 +44,25 @@ using FillArrays: SquareEye
         end
     end
 
-    # A = Zeros(4, 3)
-    # Q, R = @constinferred qr_compact(A)
-    # @test Q * R == A
-    # @test size(Q) == (4, 3)
-    # @test size(R) == (3, 3)
-    # @test Q == Matrix(I, (4, 3))
-    # @test Q isa Eye
-    # @test iszero(R)
-    # @test R isa Zeros
+    A = Zeros(4, 3)
+    Q, R = @constinferred qr_compact(A)
+    @test Q * R == A
+    @test size(Q) == (4, 3)
+    @test size(R) == (3, 3)
+    @test Q == Matrix(I, (4, 3))
+    @test Q isa Eye
+    @test iszero(R)
+    @test R isa Zeros
 
-    # A = Zeros(4, 3)
-    # Q, R = @constinferred qr_full(A)
-    # @test Q * R == A
-    # @test size(Q) == (4, 4)
-    # @test size(R) == (4, 3)
-    # @test Q == I
-    # @test Q isa Eye
-    # @test iszero(R)
-    # @test R isa Zeros
+    A = Zeros(4, 3)
+    Q, R = @constinferred qr_full(A)
+    @test Q * R == A
+    @test size(Q) == (4, 4)
+    @test size(R) == (4, 3)
+    @test Q == I
+    @test Q isa Eye
+    @test iszero(R)
+    @test R isa Zeros
 
     # A = Zeros(4, 3)
     # Q, R = @constinferred left_polar(A)


### PR DESCRIPTION
This adds a package extension for [FillArrays.jl](https://github.com/JuliaArrays/FillArrays.jl) to define specialized factorization overloads for certain types defined in that package, in particular `Zeros` that lazily represents a matrix of all zeros and `Eye` that lazily represents a square or rectangular identity matrix. We can of course support other FillArrays.jl types, but those are the ones I have a use case for and they are pretty simple so I focused on those for now.

The idea is that where possible the factorizations return factors that are either `Zeros` or `Eye` if that can be known at compile time (i.e. in a type stable way).

It looks like a lot of code, but the definitions are all pretty simple. The basic code pattern is that I overload `copy_input` and `initialize_output` to be no-ops since the objects are immutable, and then the factorization definitions construct the output types based on the sizes/axes of the inputs.

I've marked this as work-in-progress because it depends on changes made in #32 to avoid code duplication in `default_algorithm` definitions, and also that PR will make it a little easier to implement `left_polar`/`right_polar` (which still needs to be implemented). I also haven't implement `left_null`/`right_null` and haven't tested `left_orth`/`right_orth`, since this PR is already very big I may leave that for future work. However, it would still be good to get some feedback on the approach I'm using.