### PR TITLE
Pullback rules for truncation methods

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MatrixAlgebraKit"
 uuid = "6c742aac-3347-4629-af66-fc926824e5e4"
 authors = ["Jutho <jutho.haegeman@ugent.be> and contributors"]
-version = "0.4.0"
+version = "0.4.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/ext/MatrixAlgebraKitChainRulesCoreExt.jl
+++ b/ext/MatrixAlgebraKitChainRulesCoreExt.jl
@@ -2,7 +2,7 @@ module MatrixAlgebraKitChainRulesCoreExt
 
 using MatrixAlgebraKit
 using MatrixAlgebraKit: copy_input, initialize_output, zero!, diagview,
-    TruncatedAlgorithm, findtruncated, findtruncated_sorted
+    TruncatedAlgorithm, findtruncated, findtruncated_svd
 using ChainRulesCore
 using LinearAlgebra
 
@@ -25,7 +25,7 @@ for qr_f in (:qr_compact, :qr_full)
             QR = $(qr_f!)(Ac, QR, alg)
             function qr_pullback(ΔQR)
                 ΔA = zero(A)
-                MatrixAlgebraKit.qr_compact_pullback!(ΔA, QR, unthunk.(ΔQR))
+                MatrixAlgebraKit.qr_compact_pullback!(ΔA, A, QR, unthunk.(ΔQR))
                 return NoTangent(), ΔA, ZeroTangent(), NoTangent()
             end
             function qr_pullback(::Tuple{ZeroTangent, ZeroTangent}) # is this extra definition useful?
@@ -46,7 +46,7 @@ function ChainRulesCore.rrule(::typeof(qr_null!), A::AbstractMatrix, N, alg)
         minmn = min(m, n)
         ΔQ = zero!(similar(A, (m, m)))
         view(ΔQ, 1:m, (minmn + 1):m) .= unthunk.(ΔN)
-        MatrixAlgebraKit.qr_compact_pullback!(ΔA, (Q, R), (ΔQ, ZeroTangent()))
+        MatrixAlgebraKit.qr_compact_pullback!(ΔA, A, (Q, R), (ΔQ, ZeroTangent()))
         return NoTangent(), ΔA, ZeroTangent(), NoTangent()
     end
     function qr_null_pullback(::ZeroTangent) # is this extra definition useful?
@@ -63,7 +63,7 @@ for lq_f in (:lq_compact, :lq_full)
             LQ = $(lq_f!)(Ac, LQ, alg)
             function lq_pullback(ΔLQ)
                 ΔA = zero(A)
-                MatrixAlgebraKit.lq_compact_pullback!(ΔA, LQ, unthunk.(ΔLQ))
+                MatrixAlgebraKit.lq_compact_pullback!(ΔA, A, LQ, unthunk.(ΔLQ))
                 return NoTangent(), ΔA, ZeroTangent(), NoTangent()
             end
             function lq_pullback(::Tuple{ZeroTangent, ZeroTangent}) # is this extra definition useful?
@@ -84,7 +84,7 @@ function ChainRulesCore.rrule(::typeof(lq_null!), A::AbstractMatrix, Nᴴ, alg)
         minmn = min(m, n)
         ΔQ = zero!(similar(A, (n, n)))
         view(ΔQ, (minmn + 1):n, 1:n) .= unthunk.(ΔNᴴ)
-        MatrixAlgebraKit.lq_compact_pullback!(ΔA, (L, Q), (ZeroTangent(), ΔQ))
+        MatrixAlgebraKit.lq_compact_pullback!(ΔA, A, (L, Q), (ZeroTangent(), ΔQ))
         return NoTangent(), ΔA, ZeroTangent(), NoTangent()
     end
     function lq_null_pullback(::ZeroTangent) # is this extra definition useful?
@@ -107,7 +107,7 @@ for eig in (:eig, :eigh)
             DV = $(eig_f!)(Ac, DV, alg)
             function $eig_pb(ΔDV)
                 ΔA = zero(A)
-                MatrixAlgebraKit.$eig_pb!(ΔA, DV, unthunk.(ΔDV))
+                MatrixAlgebraKit.$eig_pb!(ΔA, A, DV, unthunk.(ΔDV))
                 return NoTangent(), ΔA, ZeroTangent(), NoTangent()
             end
             function $eig_pb(::Tuple{ZeroTangent, ZeroTangent}) # is this extra definition useful?
@@ -120,15 +120,15 @@ for eig in (:eig, :eigh)
                 alg::TruncatedAlgorithm
             )
             Ac = copy_input($eig_f, A)
-            D, V = $(eig_f!)(Ac, DV, alg)
+            D, V = $(eig_f!)(Ac, DV, alg.alg)
             ind = findtruncated(diagview(D), alg.trunc)
             return (Diagonal(diagview(D)[ind]), V[:, ind]),
-                _make_eig_t_pb(A, (D, V), ind)
+                $(_make_eig_t_pb)(A, (D, V), ind)
         end
         function $(_make_eig_t_pb)(A, DV, ind)
             function $eig_t_pb(ΔDV)
                 ΔA = zero(A)
-                MatrixAlgebraKit.$eig_pb!(ΔA, DV, unthunk.(ΔDV), ind)
+                MatrixAlgebraKit.$eig_pb!(ΔA, A, DV, unthunk.(ΔDV), ind)
                 return NoTangent(), ΔA, ZeroTangent(), NoTangent()
             end
             function $eig_t_pb(::Tuple{ZeroTangent, ZeroTangent}) # is this extra definition useful?
@@ -147,7 +147,7 @@ for svd_f in (:svd_compact, :svd_full)
             USVᴴ = $(svd_f!)(Ac, USVᴴ, alg)
             function svd_pullback(ΔUSVᴴ)
                 ΔA = zero(A)
-                MatrixAlgebraKit.svd_pullback!(ΔA, USVᴴ, unthunk.(ΔUSVᴴ))
+                MatrixAlgebraKit.svd_pullback!(ΔA, A, USVᴴ, unthunk.(ΔUSVᴴ))
                 return NoTangent(), ΔA, ZeroTangent(), NoTangent()
             end
             function svd_pullback(::Tuple{ZeroTangent, ZeroTangent, ZeroTangent}) # is this extra definition useful?
@@ -164,14 +164,14 @@ function ChainRulesCore.rrule(
     )
     Ac = copy_input(svd_compact, A)
     U, S, Vᴴ = svd_compact!(Ac, USVᴴ, alg.alg)
-    ind = findtruncated_sorted(diagview(S), alg.trunc)
+    ind = findtruncated_svd(diagview(S), alg.trunc)
     return (U[:, ind], Diagonal(diagview(S)[ind]), Vᴴ[ind, :]),
         _make_svd_trunc_pullback(A, (U, S, Vᴴ), ind)
 end
 function _make_svd_trunc_pullback(A, USVᴴ, ind)
     function svd_trunc_pullback(ΔUSVᴴ)
         ΔA = zero(A)
-        MatrixAlgebraKit.svd_pullback!(ΔA, USVᴴ, unthunk.(ΔUSVᴴ), ind)
+        MatrixAlgebraKit.svd_pullback!(ΔA, A, USVᴴ, unthunk.(ΔUSVᴴ), ind)
         return NoTangent(), ΔA, ZeroTangent(), NoTangent()
     end
     function svd_trunc_pullback(::Tuple{ZeroTangent, ZeroTangent, ZeroTangent}) # is this extra definition useful?
@@ -185,7 +185,7 @@ function ChainRulesCore.rrule(::typeof(left_polar!), A::AbstractMatrix, WP, alg)
     WP = left_polar!(Ac, WP, alg)
     function left_polar_pullback(ΔWP)
         ΔA = zero(A)
-        MatrixAlgebraKit.left_polar_pullback!(ΔA, WP, unthunk.(ΔWP))
+        MatrixAlgebraKit.left_polar_pullback!(ΔA, A, WP, unthunk.(ΔWP))
         return NoTangent(), ΔA, ZeroTangent(), NoTangent()
     end
     function left_polar_pullback(::Tuple{ZeroTangent, ZeroTangent}) # is this extra definition useful?
@@ -199,7 +199,7 @@ function ChainRulesCore.rrule(::typeof(right_polar!), A::AbstractMatrix, PWᴴ, 
     PWᴴ = right_polar!(Ac, PWᴴ, alg)
     function right_polar_pullback(ΔPWᴴ)
         ΔA = zero(A)
-        MatrixAlgebraKit.right_polar_pullback!(ΔA, PWᴴ, unthunk.(ΔPWᴴ))
+        MatrixAlgebraKit.right_polar_pullback!(ΔA, A, PWᴴ, unthunk.(ΔPWᴴ))
         return NoTangent(), ΔA, ZeroTangent(), NoTangent()
     end
     function right_polar_pullback(::Tuple{ZeroTangent, ZeroTangent}) # is this extra definition useful?

--- a/src/MatrixAlgebraKit.jl
+++ b/src/MatrixAlgebraKit.jl
@@ -53,6 +53,13 @@ export notrunc, truncrank, trunctol, truncerror, truncfilter
             :TruncationByError, :TruncationIntersection
         )
     )
+    eval(
+        Expr(
+            :public, :qr_compact_pullback!, :lq_compact_pullback!, :left_polar_pullback!,
+            :right_polar_pullback!, :eig_pullback!, :eig_trunc_pullback!, :eigh_pullback!,
+            :eigh_trunc_pullback!, :svd_pullback!, :svd_trunc_pullback!
+        )
+    )
 end
 
 include("common/defaults.jl")

--- a/src/pullbacks/eig.jl
+++ b/src/pullbacks/eig.jl
@@ -1,7 +1,29 @@
-function eig_full_pullback!(
-        ΔA::AbstractMatrix, DV, ΔDV;
+"""
+    eig_pullback!(ΔA, DV, ΔDV, ind=nothing;
+                    tol=default_pullback_gaugetol(DV[1]),
+                    degeneracy_atol=tol,
+                    gauge_atol=tol)
+
+Adds the pullback from the Hermitian eigenvalue decomposition of `A` to `ΔA`,
+given the output `DV` of `eigh_full` and the cotangent `ΔDV` of `eig_full` or `eig_trunc`.
+
+In particular, it is assumed that `A ≈ V * D * inv(V)` with thus `size(A) == size(V) == size(D)`
+and `D` diagonal. For the cotangents, an arbitrary number of eigenvectors or eigenvalues can
+be missing, i.e. for a matrix `A` of size `(n, n)`, `ΔV` can have size `(n, pV)` and
+`diagview(ΔD)` can have length `pD`. In those cases, it is assumed that these
+correspond to the first `pV` or `pD` eigenvectors or values, unless `ind` is provided,
+in which case it is assumed that they correspond to the eigenvectors or values with
+indices `ind`, and thus `length(ind) == pV == pD`.
+
+A warning will be printed if the cotangents are not gauge-invariant, i.e. if the
+restriction of `V' * ΔV` to rows `i` and columns `j` for which
+`abs(D[i] - D[j]) < degeneracy_atol`, is not small compared to `gauge_atol`.
+"""
+function eig_pullback!(
+        ΔA::AbstractMatrix, DV, ΔDV, ind = nothing;
         tol::Real = default_pullback_gaugetol(DV[1]),
-        degeneracy_atol::Real = tol, gauge_atol::Real = tol
+        degeneracy_atol::Real = tol,
+        gauge_atol::Real = tol
     )
 
     # Basic size checks and determination
@@ -12,29 +34,55 @@ function eig_full_pullback!(
     n == length(D) || throw(DimensionMismatch())
 
     if !iszerotangent(ΔV)
-        VdΔV = V' * ΔV
+        n == size(ΔV, 1) || throw(DimensionMismatch())
+        pV = size(ΔV, 2)
+        VᴴΔV = fill!(similar(V), 0)
+        if isnothing(ind)
+            indV = 1:pV # default assumption?
+        else
+            length(ind) == pV || throw(DimensionMismatch())
+            indV = ind
+        end
+        mul!(view(VᴴΔV, :, indV), V', ΔV)
 
         mask = abs.(transpose(D) .- D) .< degeneracy_atol
-        Δgauge = norm(view(VdΔV, mask), Inf)
+        Δgauge = norm(view(VᴴΔV, mask), Inf)
         Δgauge < gauge_atol ||
             @warn "`eig` cotangents sensitive to gauge choice: (|Δgauge| = $Δgauge)"
 
-        VdΔV .*= conj.(inv_safe.(transpose(D) .- D, degeneracy_atol))
+        VᴴΔV .*= conj.(inv_safe.(transpose(D) .- D, degeneracy_atol))
 
         if !iszerotangent(ΔDmat)
-            diagview(VdΔV) .+= diagview(ΔDmat)
+            ΔDvec = diagview(ΔDmat)
+            pD = length(ΔDvec)
+            if isnothing(ind)
+                indD = 1:pD # default assumption?
+            else
+                length(ind) == pD || throw(DimensionMismatch())
+                indD = ind
+            end
+            view(diagview(VᴴΔV), indD) .+= ΔDvec
         end
-        PΔV = V' \ VdΔV
+        PΔV = V' \ VᴴΔV
         if eltype(ΔA) <: Real
-            ΔAc = mul!(VdΔV, PΔV, V') # recycle VdΔV memory
+            ΔAc = mul!(VᴴΔV, PΔV, V') # recycle VdΔV memory
             ΔA .+= real.(ΔAc)
         else
             ΔA = mul!(ΔA, PΔV, V', 1, 1)
         end
     elseif !iszerotangent(ΔDmat)
-        PΔV = V' \ Diagonal(diagview(ΔDmat))
+        ΔDvec = diagview(ΔDmat)
+        pD = length(ΔDvec)
+        if isnothing(ind)
+            indD = 1:pD # default assumption?
+        else
+            length(ind) == pD || throw(DimensionMismatch())
+            indD = ind
+        end
+        Vp = view(V, :, indD)
+        PΔV = Vp' \ Diagonal(ΔDvec)
         if eltype(ΔA) <: Real
-            ΔAc = PΔV * V'
+            ΔAc = PΔV * Vp'
             ΔA .+= real.(ΔAc)
         else
             ΔA = mul!(ΔA, PΔV, V', 1, 1)

--- a/src/pullbacks/eig.jl
+++ b/src/pullbacks/eig.jl
@@ -1,23 +1,24 @@
 """
-    eig_pullback!(ΔA::AbstractMatrix, A, DV, ΔDV, ind = nothing;
-                    tol=default_pullback_gaugetol(DV[1]),
-                    degeneracy_atol=tol,
-                    gauge_atol=tol)
+    eig_pullback!(
+        ΔA::AbstractMatrix, A, DV, ΔDV, [ind];
+        tol = default_pullback_gaugetol(DV[1]),
+        degeneracy_atol = tol,
+        gauge_atol = tol
+    )
 
-Adds the pullback from the full eigenvalue decomposition of `A` to `ΔA`,
-given the output `DV` of `eig_full` and the cotangent `ΔDV` of `eig_full` or `eig_trunc`.
+Adds the pullback from the full eigenvalue decomposition of `A` to `ΔA`, given the output
+`DV` of `eig_full` and the cotangent `ΔDV` of `eig_full` or `eig_trunc`.
 
-In particular, it is assumed that `A ≈ V * D * inv(V)` with thus `size(A) == size(V) == size(D)`
-and `D` diagonal. For the cotangents, an arbitrary number of eigenvectors or eigenvalues can
-be missing, i.e. for a matrix `A` of size `(n, n)`, `ΔV` can have size `(n, pV)` and
-`diagview(ΔD)` can have length `pD`. In those cases, it is assumed that these
-correspond to the first `pV` or `pD` eigenvectors or values, unless `ind` is provided,
-in which case it is assumed that they correspond to the eigenvectors or values with
-indices `ind`, and thus `length(ind) == pV == pD`.
+In particular, it is assumed that `A ≈ V * D * inv(V)` with thus
+`size(A) == size(V) == size(D)` and `D` diagonal. For the cotangents, an arbitrary number of
+eigenvectors or eigenvalues can be missing, i.e. for a matrix `A` of size `(n, n)`, `ΔV` can
+have size `(n, pV)` and `diagview(ΔD)` can have length `pD`. In those cases, additionally
+`ind` is required to specify which eigenvectors or eigenvalues are present in `ΔV` or `ΔD`.
+By default, it is assumed that all eigenvectors and eigenvalues are present.
 
-A warning will be printed if the cotangents are not gauge-invariant, i.e. if the
-restriction of `V' * ΔV` to rows `i` and columns `j` for which
-`abs(D[i] - D[j]) < degeneracy_atol`, is not small compared to `gauge_atol`.
+A warning will be printed if the cotangents are not gauge-invariant, i.e. if the restriction
+of `V' * ΔV` to rows `i` and columns `j` for which `abs(D[i] - D[j]) < degeneracy_atol`, is
+not small compared to `gauge_atol`.
 """
 function eig_pullback!(
         ΔA::AbstractMatrix, A, DV, ΔDV, ind = Colon();
@@ -81,13 +82,15 @@ function eig_pullback!(
 end
 
 """
-    eig_trunc_pullback!(ΔA::AbstractMatrix, ΔDV, A, DV;
-                    tol=default_pullback_gaugetol(DV[1]),
-                    degeneracy_atol=tol,
-                    gauge_atol=tol)
+    eig_trunc_pullback!(
+        ΔA::AbstractMatrix, ΔDV, A, DV;
+        tol = default_pullback_gaugetol(DV[1]),
+        degeneracy_atol = tol,
+        gauge_atol = tol
+    )
 
-Adds the pullback from the truncated eigenvalue decomposition of `A` to `ΔA`,
-given the output `DV` and the cotangent `ΔDV` of `eig_trunc`.
+Adds the pullback from the truncated eigenvalue decomposition of `A` to `ΔA`, given the
+output `DV` and the cotangent `ΔDV` of `eig_trunc`.
 
 In particular, it is assumed that `A * V ≈ V * D` with `V` a rectangular matrix of
 eigenvectors and `D` diagonal. For the cotangents, it is assumed that if `ΔV` is not zero,
@@ -97,9 +100,9 @@ diagonal matrix of the same size as `D`.
 For this method to work correctly, it is also assumed that the remaining eigenvalues
 (not included in `D`) are (sufficiently) separated from those in `D`.
 
-A warning will be printed if the cotangents are not gauge-invariant, i.e. if the
-restriction of `V' * ΔV` to rows `i` and columns `j` for which
-`abs(D[i] - D[j]) < degeneracy_atol`, is not small compared to `gauge_atol`.
+A warning will be printed if the cotangents are not gauge-invariant, i.e. if the restriction
+of `V' * ΔV` to rows `i` and columns `j` for which `abs(D[i] - D[j]) < degeneracy_atol`, is
+not small compared to `gauge_atol`.
 """
 function eig_trunc_pullback!(
         ΔA::AbstractMatrix, A, DV, ΔDV;

--- a/src/pullbacks/eig.jl
+++ b/src/pullbacks/eig.jl
@@ -20,7 +20,7 @@ restriction of `V' * ΔV` to rows `i` and columns `j` for which
 `abs(D[i] - D[j]) < degeneracy_atol`, is not small compared to `gauge_atol`.
 """
 function eig_pullback!(
-        ΔA::AbstractMatrix, A, DV, ΔDV, ind = nothing;
+        ΔA::AbstractMatrix, A, DV, ΔDV, ind = Colon();
         tol::Real = default_pullback_gaugetol(DV[1]),
         degeneracy_atol::Real = tol,
         gauge_atol::Real = tol
@@ -38,12 +38,8 @@ function eig_pullback!(
         n == size(ΔV, 1) || throw(DimensionMismatch())
         pV = size(ΔV, 2)
         VᴴΔV = fill!(similar(V), 0)
-        if isnothing(ind)
-            indV = 1:pV # default assumption?
-        else
-            length(ind) == pV || throw(DimensionMismatch())
-            indV = ind
-        end
+        indV = axes(V, 2)[ind]
+        length(indV) == pV || throw(DimensionMismatch())
         mul!(view(VᴴΔV, :, indV), V', ΔV)
 
         mask = abs.(transpose(D) .- D) .< degeneracy_atol
@@ -56,12 +52,8 @@ function eig_pullback!(
         if !iszerotangent(ΔDmat)
             ΔDvec = diagview(ΔDmat)
             pD = length(ΔDvec)
-            if isnothing(ind)
-                indD = 1:pD # default assumption?
-            else
-                length(ind) == pD || throw(DimensionMismatch())
-                indD = ind
-            end
+            indD = axes(D, 1)[ind]
+            length(indD) == pD || throw(DimensionMismatch())
             view(diagview(VᴴΔV), indD) .+= ΔDvec
         end
         PΔV = V' \ VᴴΔV
@@ -74,12 +66,8 @@ function eig_pullback!(
     elseif !iszerotangent(ΔDmat)
         ΔDvec = diagview(ΔDmat)
         pD = length(ΔDvec)
-        if isnothing(ind)
-            indD = 1:pD # default assumption?
-        else
-            length(ind) == pD || throw(DimensionMismatch())
-            indD = ind
-        end
+        indD = axes(D, 1)[ind]
+        length(indD) == pD || throw(DimensionMismatch())
         Vp = view(V, :, indD)
         PΔV = Vp' \ Diagonal(ΔDvec)
         if eltype(ΔA) <: Real

--- a/src/pullbacks/eigh.jl
+++ b/src/pullbacks/eigh.jl
@@ -20,7 +20,7 @@ anti-hermitian part of `V' * ΔV`, restricted to rows `i` and columns `j`
 for which `abs(D[i] - D[j]) < degeneracy_atol`, is not small compared to `gauge_atol`.
 """
 function eigh_pullback!(
-        ΔA::AbstractMatrix, A, DV, ΔDV, ind = nothing;
+        ΔA::AbstractMatrix, A, DV, ΔDV, ind = Colon();
         tol::Real = default_pullback_gaugetol(DV[1]),
         degeneracy_atol::Real = tol,
         gauge_atol::Real = tol
@@ -38,12 +38,8 @@ function eigh_pullback!(
         n == size(ΔV, 1) || throw(DimensionMismatch())
         pV = size(ΔV, 2)
         VᴴΔV = fill!(similar(V), 0)
-        if isnothing(ind)
-            indV = 1:pV # default assumption?
-        else
-            length(ind) == pV || throw(DimensionMismatch())
-            indV = ind
-        end
+        indV = axes(V, 2)[ind]
+        length(indV) == pV || throw(DimensionMismatch())
         mul!(view(VᴴΔV, :, indV), V', ΔV)
         aVᴴΔV = rmul!(VᴴΔV - VᴴΔV', 1 / 2)
 
@@ -57,12 +53,8 @@ function eigh_pullback!(
         if !iszerotangent(ΔDmat)
             ΔDvec = diagview(ΔDmat)
             pD = length(ΔDvec)
-            if isnothing(ind)
-                indD = 1:pD # default assumption?
-            else
-                length(ind) == pD || throw(DimensionMismatch())
-                indD = ind
-            end
+            indD = axes(D, 1)[ind]
+            length(indD) == pD || throw(DimensionMismatch())
             view(diagview(aVᴴΔV), indD) .+= real.(ΔDvec)
         end
         # recylce VdΔV space
@@ -70,12 +62,8 @@ function eigh_pullback!(
     elseif !iszerotangent(ΔDmat)
         ΔDvec = diagview(ΔDmat)
         pD = length(ΔDvec)
-        if isnothing(ind)
-            indD = 1:pD # default assumption?
-        else
-            length(ind) == pD || throw(DimensionMismatch())
-            indD = ind
-        end
+        indD = axes(D, 1)[ind]
+        length(indD) == pD || throw(DimensionMismatch())
         Vp = view(V, :, indD)
         ΔA = mul!(ΔA, Vp * Diagonal(real(ΔDvec)), Vp', 1, 1)
     end

--- a/src/pullbacks/eigh.jl
+++ b/src/pullbacks/eigh.jl
@@ -1,23 +1,24 @@
 """
-    eigh_pullback!(ΔA::AbstractMatrix, A, DV, ΔDV, ind = nothing;
-                    tol=default_pullback_gaugetol(DV[1]),
-                    degeneracy_atol=tol,
-                    gauge_atol=tol)
+    eigh_pullback!(
+        ΔA::AbstractMatrix, A, DV, ΔDV, [ind];
+        tol = default_pullback_gaugetol(DV[1]),
+        degeneracy_atol = tol,
+        gauge_atol = tol
+    )
 
-Adds the pullback from the Hermitian eigenvalue decomposition of `A` to `ΔA`,
-given the output `DV` of `eigh_full` and the cotangent `ΔDV` of `eigh_full` or `eigh_trunc`.
+Adds the pullback from the Hermitian eigenvalue decomposition of `A` to `ΔA`, given the
+output `DV` of `eigh_full` and the cotangent `ΔDV` of `eigh_full` or `eigh_trunc`.
 
 In particular, it is assumed that `A ≈ V * D * V'` with thus `size(A) == size(V) == size(D)`
 and `D` diagonal. For the cotangents, an arbitrary number of eigenvectors or eigenvalues can
 be missing, i.e. for a matrix `A` of size `(n, n)`, `ΔV` can have size `(n, pV)` and
-`diagview(ΔD)` can have length `pD`. In those cases, it is assumed that these
-correspond to the first `pV` or `pD` eigenvectors or values, unless `ind` is provided,
-in which case it is assumed that they correspond to the eigenvectors or values with
-indices `ind`, and thus `length(ind) == pV == pD`.
+`diagview(ΔD)` can have length `pD`. In those cases, additionally `ind` is required to
+specify which eigenvectors or eigenvalues are present in `ΔV` or `ΔD`. By default, it is
+assumed that all eigenvectors and eigenvalues are present.
 
 A warning will be printed if the cotangents are not gauge-invariant, i.e. if the
-anti-hermitian part of `V' * ΔV`, restricted to rows `i` and columns `j`
-for which `abs(D[i] - D[j]) < degeneracy_atol`, is not small compared to `gauge_atol`.
+anti-hermitian part of `V' * ΔV`, restricted to rows `i` and columns `j` for which `abs(D[i]
+- D[j]) < degeneracy_atol`, is not small compared to `gauge_atol`.
 """
 function eigh_pullback!(
         ΔA::AbstractMatrix, A, DV, ΔDV, ind = Colon();
@@ -71,10 +72,12 @@ function eigh_pullback!(
 end
 
 """
-    eigh_trunc_pullback!(ΔA::AbstractMatrix, A, DV, ΔDV;
-                    tol=default_pullback_gaugetol(DV[1]),
-                    degeneracy_atol=tol,
-                    gauge_atol=tol)
+    eigh_trunc_pullback!(
+        ΔA::AbstractMatrix, A, DV, ΔDV;
+        tol=default_pullback_gaugetol(DV[1]),
+        degeneracy_atol=tol,
+        gauge_atol=tol
+    )
 
 Adds the pullback from the truncated Hermitian eigenvalue decomposition of `A` to `ΔA`,
 given the output `DV` and the cotangent `ΔDV` of `eig_trunc`.
@@ -87,9 +90,9 @@ diagonal matrix of the same size as `D`.
 For this method to work correctly, it is also assumed that the remaining eigenvalues
 (not included in `D`) are (sufficiently) separated from those in `D`.
 
-A warning will be printed if the cotangents are not gauge-invariant, i.e. if the
-restriction of `V' * ΔV` to rows `i` and columns `j` for which
-`abs(D[i] - D[j]) < degeneracy_atol`, is not small compared to `gauge_atol`.
+A warning will be printed if the cotangents are not gauge-invariant, i.e. if the restriction
+of `V' * ΔV` to rows `i` and columns `j` for which `abs(D[i] - D[j]) < degeneracy_atol`, is
+not small compared to `gauge_atol`.
 """
 function eigh_trunc_pullback!(
         ΔA::AbstractMatrix, A, DV, ΔDV;

--- a/src/pullbacks/eigh.jl
+++ b/src/pullbacks/eigh.jl
@@ -1,7 +1,29 @@
-function eigh_full_pullback!(
-        ΔA::AbstractMatrix, DV, ΔDV;
+"""
+    eigh_pullback!(ΔA, DV, ΔDV, ind=nothing;
+                    tol=default_pullback_gaugetol(DV[1]),
+                    degeneracy_atol=tol,
+                    gauge_atol=tol)
+
+Adds the pullback from the Hermitian eigenvalue decomposition of `A` to `ΔA`,
+given the output `DV` of `eigh_full` and the cotangent `ΔDV` of `eigh_full` or `eigh_trunc`.
+
+In particular, it is assumed that `A ≈ V * D * V'` with thus `size(A) == size(V) == size(D)`
+and `D` diagonal. For the cotangents, an arbitrary number of eigenvectors or eigenvalues can
+be missing, i.e. for a matrix `A` of size `(n, n)`, `ΔV` can have size `(n, pV)` and
+`diagview(ΔD)` can have length `pD`. In those cases, it is assumed that these
+correspond to the first `pV` or `pD` eigenvectors or values, unless `ind` is provided,
+in which case it is assumed that they correspond to the eigenvectors or values with
+indices `ind`, and thus `length(ind) == pV == pD`.
+
+A warning will be printed if the cotangents are not gauge-invariant, i.e. if the
+anti-hermitian part of `V' * ΔV`, restricted to rows `i` and columns `j`
+for which `abs(D[i] - D[j]) < degeneracy_atol`, is not small compared to `gauge_atol`.
+"""
+function eigh_pullback!(
+        ΔA::AbstractMatrix, DV, ΔDV, ind = nothing;
         tol::Real = default_pullback_gaugetol(DV[1]),
-        degeneracy_atol::Real = tol, gauge_atol::Real = tol
+        degeneracy_atol::Real = tol,
+        gauge_atol::Real = tol
     )
 
     # Basic size checks and determination
@@ -12,23 +34,49 @@ function eigh_full_pullback!(
     n == length(D) || throw(DimensionMismatch())
 
     if !iszerotangent(ΔV)
-        VdΔV = V' * ΔV
-        aVdΔV = rmul!(VdΔV - VdΔV', 1 / 2)
+        n == size(ΔV, 1) || throw(DimensionMismatch())
+        pV = size(ΔV, 2)
+        VᴴΔV = fill!(similar(V), 0)
+        if isnothing(ind)
+            indV = 1:pV # default assumption?
+        else
+            length(ind) == pV || throw(DimensionMismatch())
+            indV = ind
+        end
+        mul!(view(VᴴΔV, :, indV), V', ΔV)
+        aVᴴΔV = rmul!(VᴴΔV - VᴴΔV', 1 / 2)
 
         mask = abs.(D' .- D) .< degeneracy_atol
-        Δgauge = norm(view(aVdΔV, mask))
+        Δgauge = norm(view(aVᴴΔV, mask))
         Δgauge < gauge_atol ||
             @warn "`eigh` cotangents sensitive to gauge choice: (|Δgauge| = $Δgauge)"
 
-        aVdΔV .*= inv_safe.(D' .- D, tol)
+        aVᴴΔV .*= inv_safe.(D' .- D, tol)
 
         if !iszerotangent(ΔDmat)
-            diagview(aVdΔV) .+= real.(diagview(ΔDmat))
+            ΔDvec = diagview(ΔDmat)
+            pD = length(ΔDvec)
+            if isnothing(ind)
+                indD = 1:pD # default assumption?
+            else
+                length(ind) == pD || throw(DimensionMismatch())
+                indD = ind
+            end
+            view(diagview(aVᴴΔV), indD) .+= real.(ΔDvec)
         end
         # recylce VdΔV space
-        ΔA = mul!(ΔA, mul!(VdΔV, V, aVdΔV), V', 1, 1)
+        ΔA = mul!(ΔA, mul!(VᴴΔV, V, aVᴴΔV), V', 1, 1)
     elseif !iszerotangent(ΔDmat)
-        ΔA = mul!(ΔA, V * Diagonal(real(diagview(ΔDmat))), V', 1, 1)
+        ΔDvec = diagview(ΔDmat)
+        pD = length(ΔDvec)
+        if isnothing(ind)
+            indD = 1:pD # default assumption?
+        else
+            length(ind) == pD || throw(DimensionMismatch())
+            indD = ind
+        end
+        Vp = view(V, :, indD)
+        ΔA = mul!(ΔA, Vp * Diagonal(real(ΔDvec)), Vp', 1, 1)
     end
     return ΔA
 end

--- a/src/pullbacks/lq.jl
+++ b/src/pullbacks/lq.jl
@@ -1,11 +1,10 @@
 # TODO: we should somewhere check that we only call this when performing a positive LQ
 
 """
-    lq_compact_pullback!(
-        ΔA, (L, Q), (ΔL, ΔQ);
-        tol::Real = default_pullback_gaugetol(R),
-        rank_atol::Real = tol, gauge_atol::Real = tol
-    )
+    lq_compact_pullback!(ΔA, A, (L, Q), (ΔL, ΔQ);
+                            tol::Real=default_pullback_gaugetol(R),
+                            rank_atol::Real=tol,
+                            gauge_atol::Real=tol)
 
 Adds the pullback from the LQ decomposition of `A` to `ΔA` given the output `(L, Q)` and
 cotangent `(ΔL, ΔQ)` of `lq_compact(A; positive = true)` or `lq_full(A; positive = true)`.
@@ -18,9 +17,10 @@ values only in the first `r` columns and rows respectively. If nonzero values in
 remaining columns or rows exceed `gauge_atol`, a warning will be printed.
 """
 function lq_compact_pullback!(
-        ΔA::AbstractMatrix, LQ, ΔLQ;
+        ΔA::AbstractMatrix, A, LQ, ΔLQ;
         tol::Real = default_pullback_gaugetol(LQ[1]),
-        rank_atol::Real = tol, gauge_atol::Real = tol
+        rank_atol::Real = tol,
+        gauge_atol::Real = tol
     )
     # process
     L, Q = LQ

--- a/src/pullbacks/lq.jl
+++ b/src/pullbacks/lq.jl
@@ -73,7 +73,7 @@ function lq_compact_pullback!(
             ΔQ2Q1ᴴ = ΔQ2 * Q1'
             Δgauge = norm(mul!(copy(ΔQ2), ΔQ2Q1ᴴ, Q1, -1, 1), Inf)
             Δgauge < tol ||
-                @warn "`qr` cotangents sensitive to gauge choice: (|Δgauge| = $Δgauge)"
+                @warn "`lq` cotangents sensitive to gauge choice: (|Δgauge| = $Δgauge)"
             ΔQ̃ = mul!(ΔQ̃, ΔQ2Q1ᴴ', Q2, -1, 1)
         end
     end

--- a/src/pullbacks/lq.jl
+++ b/src/pullbacks/lq.jl
@@ -70,11 +70,11 @@ function lq_compact_pullback!(
             # case, Q is expected to rotate smoothly (we might even be able to predict) also
             # how the full Q2 will change, but this we omit for now, and we consider
             # Q2' * ΔQ2 as a gauge dependent quantity.
-            ΔQ2Q1d = ΔQ2 * Q1'
-            Δgauge = norm(mul!(copy(ΔQ2), ΔQ2Q1d, Q1, -1, 1), Inf)
+            ΔQ2Q1ᴴ = ΔQ2 * Q1'
+            Δgauge = norm(mul!(copy(ΔQ2), ΔQ2Q1ᴴ, Q1, -1, 1), Inf)
             Δgauge < tol ||
                 @warn "`qr` cotangents sensitive to gauge choice: (|Δgauge| = $Δgauge)"
-            ΔQ̃ = mul!(ΔQ̃, ΔQ2Q1d', Q2, -1, 1)
+            ΔQ̃ = mul!(ΔQ̃, ΔQ2Q1ᴴ', Q2, -1, 1)
         end
     end
     if !iszerotangent(ΔL) && m > p

--- a/src/pullbacks/lq.jl
+++ b/src/pullbacks/lq.jl
@@ -1,20 +1,20 @@
-# TODO: we should somewhere check that we only call this when performing a positive LQ
-
 """
-    lq_compact_pullback!(ΔA, A, (L, Q), (ΔL, ΔQ);
-                            tol::Real=default_pullback_gaugetol(R),
-                            rank_atol::Real=tol,
-                            gauge_atol::Real=tol)
+    lq_compact_pullback!(
+        ΔA, A, LQ, ΔLQ;
+        tol::Real=default_pullback_gaugetol(LQ[1]),
+        rank_atol::Real=tol,
+        gauge_atol::Real=tol
+    )
 
-Adds the pullback from the LQ decomposition of `A` to `ΔA` given the output `(L, Q)` and
-cotangent `(ΔL, ΔQ)` of `lq_compact(A; positive = true)` or `lq_full(A; positive = true)`.
+Adds the pullback from the LQ decomposition of `A` to `ΔA` given the output `LQ` and
+cotangent `ΔLQ` of `lq_compact(A; positive = true)` or `lq_full(A; positive = true)`.
 
-In the case where the rank `r` of the original matrix `A ≈ L * Q` (as determined
-by `rank_atol`) is less then the  minimum of the number of rows and columns ,
-the cotangents `ΔL` and `ΔQ`, only the first `r` columns of `L` and the first `r` rows
-of `Q` are well-defined, and also the adjoint variables `ΔL` and `ΔQ` should have nonzero
-values only in the first `r` columns and rows respectively. If nonzero values in the
-remaining columns or rows exceed `gauge_atol`, a warning will be printed.
+In the case where the rank `r` of the original matrix `A ≈ L * Q` (as determined by
+`rank_atol`) is less then the minimum of the number of rows and columns of the cotangents
+`ΔL` and `ΔQ`, only the first `r` columns of `L` and the first `r` rows of `Q` are
+well-defined, and also the adjoint variables `ΔL` and `ΔQ` should have nonzero values only
+in the first `r` columns and rows respectively. If nonzero values in the remaining columns
+or rows exceed `gauge_atol`, a warning will be printed.
 """
 function lq_compact_pullback!(
         ΔA::AbstractMatrix, A, LQ, ΔLQ;

--- a/src/pullbacks/polar.jl
+++ b/src/pullbacks/polar.jl
@@ -1,10 +1,10 @@
 """
-    left_polar_pullback!(ΔA, (W, P), (ΔW, ΔP))
+    left_polar_pullback!(ΔA, A, (W, P), (ΔW, ΔP))
 
 Adds the pullback from the left polar decomposition of `A` to `ΔA` given the output `(W, P)` and
 cotangent `(ΔW, ΔP)` of `left_polar(A)`.                        
 """
-function left_polar_pullback!(ΔA::AbstractMatrix, WP, ΔWP)
+function left_polar_pullback!(ΔA::AbstractMatrix, A, WP, ΔWP)
 
     # Extract the Polar components
     W, P = WP
@@ -30,12 +30,12 @@ function left_polar_pullback!(ΔA::AbstractMatrix, WP, ΔWP)
 end
 
 """
-    right_polar_pullback!(ΔA, (P, Wᴴ), (ΔP, ΔWᴴ))
+    right_polar_pullback!(ΔA, A, (P, Wᴴ), (ΔP, ΔWᴴ))
 
 Adds the pullback from the left polar decomposition of `A` to `ΔA` given the output `(P, Wᴴ)` and
 cotangent `(ΔP, ΔWᴴ)` of `right_polar(A)`.                        
 """
-function right_polar_pullback!(ΔA::AbstractMatrix, PWᴴ, ΔPWᴴ)
+function right_polar_pullback!(ΔA::AbstractMatrix, A, PWᴴ, ΔPWᴴ)
 
     # Extract the Polar components
     P, Wᴴ = PWᴴ

--- a/src/pullbacks/polar.jl
+++ b/src/pullbacks/polar.jl
@@ -1,11 +1,10 @@
 """
-    left_polar_pullback!(ΔA, A, (W, P), (ΔW, ΔP))
+    left_polar_pullback!(ΔA, A, WP, ΔWP)
 
-Adds the pullback from the left polar decomposition of `A` to `ΔA` given the output `(W, P)` and
-cotangent `(ΔW, ΔP)` of `left_polar(A)`.                        
+Adds the pullback from the left polar decomposition of `A` to `ΔA` given the output `WP` and
+cotangent `ΔWP` of `left_polar(A)`.
 """
 function left_polar_pullback!(ΔA::AbstractMatrix, A, WP, ΔWP)
-
     # Extract the Polar components
     W, P = WP
 
@@ -30,13 +29,12 @@ function left_polar_pullback!(ΔA::AbstractMatrix, A, WP, ΔWP)
 end
 
 """
-    right_polar_pullback!(ΔA, A, (P, Wᴴ), (ΔP, ΔWᴴ))
+    right_polar_pullback!(ΔA, A, PWᴴ, ΔPWᴴ)
 
-Adds the pullback from the left polar decomposition of `A` to `ΔA` given the output `(P, Wᴴ)` and
-cotangent `(ΔP, ΔWᴴ)` of `right_polar(A)`.                        
+Adds the pullback from the left polar decomposition of `A` to `ΔA` given the output `PWᴴ`
+and cotangent `ΔPWᴴ` of `right_polar(A)`.
 """
 function right_polar_pullback!(ΔA::AbstractMatrix, A, PWᴴ, ΔPWᴴ)
-
     # Extract the Polar components
     P, Wᴴ = PWᴴ
 

--- a/src/pullbacks/qr.jl
+++ b/src/pullbacks/qr.jl
@@ -1,11 +1,9 @@
 # TODO: we should somewhere check that we only call this when performing a positive QR without pivoting
 """
-    qr_compact_pullback!(
-        ΔA, (Q, R), (ΔQ, ΔR);
-        tol::Real = default_pullback_gaugetol(R),
-        rank_atol::Real = tol,
-        gauge_atol::Real = tol
-    )
+    qr_compact_pullback!(ΔA, A, (Q, R), (ΔQ, ΔR);
+                            tol::Real=default_pullback_gaugetol(R),
+                            rank_atol::Real=tol,
+                            gauge_atol::Real=tol)
 
 Adds the pullback from the QR decomposition of `A` to `ΔA` given the output `(Q,R)` and
 cotangent `(ΔQ, ΔR)` of `qr_compact(A; positive = true)` or `qr_full(A; positive = true)`.
@@ -18,9 +16,10 @@ only in the first `r` columns and rows respectively. If nonzero values in the re
 columns or rows exceed `gauge_atol`, a warning will be printed.
 """
 function qr_compact_pullback!(
-        ΔA::AbstractMatrix, QR, ΔQR;
+        ΔA::AbstractMatrix, A, QR, ΔQR;
         tol::Real = default_pullback_gaugetol(QR[2]),
-        rank_atol::Real = tol, gauge_atol::Real = tol
+        rank_atol::Real = tol,
+        gauge_atol::Real = tol
     )
     # process
     Q, R = QR

--- a/src/pullbacks/qr.jl
+++ b/src/pullbacks/qr.jl
@@ -1,19 +1,20 @@
-# TODO: we should somewhere check that we only call this when performing a positive QR without pivoting
 """
-    qr_compact_pullback!(ΔA, A, (Q, R), (ΔQ, ΔR);
-                            tol::Real=default_pullback_gaugetol(R),
-                            rank_atol::Real=tol,
-                            gauge_atol::Real=tol)
+    qr_compact_pullback!(
+        ΔA, A, QR, ΔQR;
+        tol::Real=default_pullback_gaugetol(QR[2]),
+        rank_atol::Real=tol,
+        gauge_atol::Real=tol
+    )
 
-Adds the pullback from the QR decomposition of `A` to `ΔA` given the output `(Q,R)` and
-cotangent `(ΔQ, ΔR)` of `qr_compact(A; positive = true)` or `qr_full(A; positive = true)`.
+Adds the pullback from the QR decomposition of `A` to `ΔA` given the output `QR` and
+cotangent `ΔQR` of `qr_compact(A; positive = true)` or `qr_full(A; positive = true)`.
 
 In the case where the rank `r` of the original matrix `A ≈ Q * R` (as determined by
-`rank_atol`) is less then the minimum of the number of rows and columns, the cotangents
-`ΔQ` and `ΔR`, only the first `r` columns of `Q` and the first `r` rows of `R` are
-well-defined, and also the adjoint variables `ΔQ` and `ΔR` should have nonzero values
-only in the first `r` columns and rows respectively. If nonzero values in the remaining
-columns or rows exceed `gauge_atol`, a warning will be printed.
+`rank_atol`) is less then the minimum of the number of rows and columns, the cotangents `ΔQ`
+and `ΔR`, only the first `r` columns of `Q` and the first `r` rows of `R` are well-defined,
+and also the adjoint variables `ΔQ` and `ΔR` should have nonzero values only in the first
+`r` columns and rows respectively. If nonzero values in the remaining columns or rows exceed
+`gauge_atol`, a warning will be printed.
 """
 function qr_compact_pullback!(
         ΔA::AbstractMatrix, A, QR, ΔQR;

--- a/src/pullbacks/svd.jl
+++ b/src/pullbacks/svd.jl
@@ -37,7 +37,7 @@ function svd_pullback!(
     minmn = min(m, n)
     S = diagview(Smat)
     length(S) == minmn || throw(DimensionMismatch())
-    r = findlast(>=(rank_atol), S) # rank
+    r = searchsortedlast(S, tol; rev = true) # rank
     Ur = view(U, :, 1:r)
     Vᴴr = view(Vᴴ, 1:r, :)
     Sr = view(S, 1:r)

--- a/src/pullbacks/svd.jl
+++ b/src/pullbacks/svd.jl
@@ -23,7 +23,7 @@ anti-hermitian part of `U' * ΔU + Vᴴ * ΔVᴴ'`, restricted to rows `i` and c
 for which `abs(S[i] - S[j]) < degeneracy_atol`, is not small compared to `gauge_atol`.
 """
 function svd_pullback!(
-        ΔA::AbstractMatrix, A, USVᴴ, ΔUSVᴴ, ind = nothing;
+        ΔA::AbstractMatrix, A, USVᴴ, ΔUSVᴴ, ind = Colon();
         tol::Real = default_pullback_gaugetol(USVᴴ[2]),
         rank_atol::Real = tol,
         degeneracy_atol::Real = tol,
@@ -50,12 +50,8 @@ function svd_pullback!(
         m == size(ΔU, 1) || throw(DimensionMismatch())
         pU = size(ΔU, 2)
         pU > r && throw(DimensionMismatch())
-        if isnothing(ind)
-            indU = 1:pU # default assumption?
-        else
-            length(ind) == pU || throw(DimensionMismatch())
-            indU = ind
-        end
+        indU = axes(U, 2)[ind]
+        length(indU) == pU || throw(DimensionMismatch())
         UΔUp = view(UΔU, :, indU)
         mul!(UΔUp, Ur', ΔU)
         ΔU -= Ur * UΔUp
@@ -64,12 +60,8 @@ function svd_pullback!(
         n == size(ΔVᴴ, 2) || throw(DimensionMismatch())
         pV = size(ΔVᴴ, 1)
         pV > r && throw(DimensionMismatch())
-        if isnothing(ind)
-            indV = 1:pV # default assumption?
-        else
-            length(ind) == pV || throw(DimensionMismatch())
-            indV = ind
-        end
+        indV = axes(Vᴴ, 1)[ind]
+        length(indV) == pV || throw(DimensionMismatch())
         VΔVp = view(VΔV, :, indV)
         mul!(VΔVp, Vᴴr, ΔVᴴ')
         ΔVᴴ = ΔVᴴ - VΔVp' * Vᴴr
@@ -90,12 +82,8 @@ function svd_pullback!(
     if !iszerotangent(ΔSmat)
         ΔS = diagview(ΔSmat)
         pS = length(ΔS)
-        if isnothing(ind)
-            indS = 1:pS # default assumption?
-        else
-            length(ind) == pS || throw(DimensionMismatch())
-            indS = ind
-        end
+        indS = axes(S, 1)[ind]
+        length(indS) == pS || throw(DimensionMismatch())
         view(diagview(UdΔAV), indS) .+= real.(ΔS)
     end
     ΔA = mul!(ΔA, Ur, UdΔAV * Vᴴr, 1, 1) # add the contribution to ΔA

--- a/src/pullbacks/svd.jl
+++ b/src/pullbacks/svd.jl
@@ -1,26 +1,25 @@
 """
-    svd_pullback!(ΔA, A, USVᴴ, ΔUSVᴴ, ind=nothing;
-                            tol::Real=default_pullback_gaugetol(S),
-                            rank_atol::Real = tol,
-                            degeneracy_atol::Real = tol,
-                            gauge_atol::Real = tol)
+    svd_pullback!(
+        ΔA, A, USVᴴ, ΔUSVᴴ, [ind];
+        tol::Real=default_pullback_gaugetol(USVᴴ[2]),
+        rank_atol::Real = tol,
+        degeneracy_atol::Real = tol,
+        gauge_atol::Real = tol
+    )
 
-Adds the pullback from the SVD of `A` to `ΔA` given the output USVᴴ of `svd_compact`
-or `svd_full` and the cotangent `ΔUSVᴴ` of `svd_compact`, `svd_full` or `svd_trunc`.
+Adds the pullback from the SVD of `A` to `ΔA` given the output USVᴴ of `svd_compact` or
+`svd_full` and the cotangent `ΔUSVᴴ` of `svd_compact`, `svd_full` or `svd_trunc`.
 
-In particular, it is assumed that `A ≈ U * S * Vᴴ`, or thus, that no singular values
-with magnitude less than `rank_atol` are missing from `S`.
-For the cotangents, an arbitrary number of singular vectors or singular values can
-be missing, i.e. for a matrix `A` with size `(m, n)`, `ΔU` and `ΔVᴴ` can have sizes
-`(m, pU)` and `(pV, n)` respectively, whereas `diagview(ΔS)` can have length `pS`.
-In those cases, it is assumed that these correspond to the first `pU`, `pV` or `pS`
-singular vectors or values, unless `ind` is provided, in which case it is assumed
-that they correspond to the singular vectors or values with indices `ind`, and thus
-`length(ind) == pU == pV == pS`.
+In particular, it is assumed that `A ≈ U * S * Vᴴ`, or thus, that no singular values with
+magnitude less than `rank_atol` are missing from `S`.  For the cotangents, an arbitrary
+number of singular vectors or singular values can be missing, i.e. for a matrix `A` with
+size `(m, n)`, `ΔU` and `ΔVᴴ` can have sizes `(m, pU)` and `(pV, n)` respectively, whereas
+`diagview(ΔS)` can have length `pS`. In those cases, additionally `ind` is required to
+specify which singular vectors and values are present in `ΔU`, `ΔS` and `ΔVᴴ`.
 
 A warning will be printed if the cotangents are not gauge-invariant, i.e. if the
-anti-hermitian part of `U' * ΔU + Vᴴ * ΔVᴴ'`, restricted to rows `i` and columns `j`
-for which `abs(S[i] - S[j]) < degeneracy_atol`, is not small compared to `gauge_atol`.
+anti-hermitian part of `U' * ΔU + Vᴴ * ΔVᴴ'`, restricted to rows `i` and columns `j` for
+which `abs(S[i] - S[j]) < degeneracy_atol`, is not small compared to `gauge_atol`.
 """
 function svd_pullback!(
         ΔA::AbstractMatrix, A, USVᴴ, ΔUSVᴴ, ind = Colon();
@@ -103,26 +102,27 @@ function svd_pullback!(
 end
 
 """
-    svd_trunc_pullback!(ΔA, A, USVᴴ, ΔUSVᴴ, ind=nothing;
-                            tol::Real=default_pullback_gaugetol(S),
-                            rank_atol::Real = tol,
-                            degeneracy_atol::Real = tol,
-                            gauge_atol::Real = tol)
+    svd_trunc_pullback!(
+        ΔA, A, USVᴴ, ΔUSVᴴ;
+        tol::Real=default_pullback_gaugetol(S),
+        rank_atol::Real = tol,
+        degeneracy_atol::Real = tol,
+        gauge_atol::Real = tol
+    )
 
-Adds the pullback from the truncated SVD of `A` to `ΔA`, given the output `USVᴴ``
-and the cotangent `ΔUSVᴴ` of `svd_trunc`.
+Adds the pullback from the truncated SVD of `A` to `ΔA`, given the output `USVᴴ` and the
+cotangent `ΔUSVᴴ` of `svd_trunc`.
 
-In particular, it is assumed that `A * Vᴴ' ≈ U * S` and `U' * A = S * Vᴴ`, with
-`U` and `Vᴴ` rectangular matrices of left and right singular vectors, and `S`
-diagonal. For the cotangents, it is assumed that if `ΔU` and `ΔVᴴ` are not zero,
-then they have the same size as `U` and `Vᴴ` (respectively), and if `ΔS` is not zero,
-then it is a diagonal matrix of the same size as `S`. For this method to work correctly,
-it is also assumed that the remaining singular values (not included in `S`) are
-(sufficiently) separated from those in `S`.
+In particular, it is assumed that `A * Vᴴ' ≈ U * S` and `U' * A = S * Vᴴ`, with `U` and `Vᴴ`
+rectangular matrices of left and right singular vectors, and `S` diagonal. For the
+cotangents, it is assumed that if `ΔU` and `ΔVᴴ` are not zero, then they have the same size
+as `U` and `Vᴴ` (respectively), and if `ΔS` is not zero, then it is a diagonal matrix of the
+same size as `S`. For this method to work correctly, it is also assumed that the remaining
+singular values (not included in `S`) are (sufficiently) separated from those in `S`.
 
 A warning will be printed if the cotangents are not gauge-invariant, i.e. if the
-anti-hermitian part of `U' * ΔU + Vᴴ * ΔVᴴ'`, restricted to rows `i` and columns `j`
-for which `abs(S[i] - S[j]) < degeneracy_atol`, is not small compared to `gauge_atol`.
+anti-hermitian part of `U' * ΔU + Vᴴ * ΔVᴴ'`, restricted to rows `i` and columns `j` for
+which `abs(S[i] - S[j]) < degeneracy_atol`, is not small compared to `gauge_atol`.
 """
 function svd_trunc_pullback!(
         ΔA::AbstractMatrix, A, USVᴴ, ΔUSVᴴ;

--- a/src/pullbacks/svd.jl
+++ b/src/pullbacks/svd.jl
@@ -53,7 +53,7 @@ function svd_pullback!(
         length(indU) == pU || throw(DimensionMismatch())
         UΔUp = view(UΔU, :, indU)
         mul!(UΔUp, Ur', ΔU)
-        ΔU -= Ur * UΔUp
+        mul!(ΔU, Ur, UΔUp, -1, 1)
     end
     if !iszerotangent(ΔVᴴ)
         n == size(ΔVᴴ, 2) || throw(DimensionMismatch())
@@ -63,7 +63,7 @@ function svd_pullback!(
         length(indV) == pV || throw(DimensionMismatch())
         VΔVp = view(VΔV, :, indV)
         mul!(VΔVp, Vᴴr, ΔVᴴ')
-        ΔVᴴ = ΔVᴴ - VΔVp' * Vᴴr
+        mul!(ΔVᴴ, VΔVp', Vᴴr, -1, 1)
     end
 
     # Project onto antihermitian part; hermitian part outside of Grassmann tangent space
@@ -152,7 +152,7 @@ function svd_trunc_pullback!(
     if !iszerotangent(ΔVᴴ)
         (p, n) == size(ΔVᴴ) || throw(DimensionMismatch())
         mul!(VΔV, Vᴴ, ΔVᴴ')
-        ΔVᴴ = ΔVᴴ - VΔV' * Vᴴ
+        mul!(ΔVᴴ, VΔV', Vᴴ, -1, 1)
     end
 
     # Project onto antihermitian part; hermitian part outside of Grassmann tangent space

--- a/src/pullbacks/svd.jl
+++ b/src/pullbacks/svd.jl
@@ -208,7 +208,7 @@ function svd_trunc_pullback!(
     else
         fill!(view(rhs, m̃ .+ (1:ñ), :), 0)
     end
-    XY = sylvester(ÃÃ, -S, -rhs)
+    XY = sylvester(ÃÃ, -Smat, rhs)
     X = view(XY, 1:m̃, :)
     Y = view(XY, m̃ .+ (1:ñ), :)
     ΔA = mul!(ΔA, Ũ, X * Vᴴ, 1, 1)

--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -314,19 +314,33 @@ end
         for r in 1:4:m
             truncalg = TruncatedAlgorithm(alg, truncrank(r; by = abs))
             r = MatrixAlgebraKit.findtruncated(Ddiag, truncalg.trunc)
+            Dtrunc = Diagonal(diagview(D)[r])
+            Vtrunc = V[:, r]
+            ΔDtrunc = Diagonal(diagview(ΔD2)[r])
+            ΔVtrunc = ΔV[:, r]
             test_rrule(
                 copy_eigh_trunc, A, truncalg ⊢ NoTangent();
                 output_tangent = (ΔD2[r, r], ΔV[:, r]),
                 atol = atol, rtol = rtol
             )
+            dA1 = MatrixAlgebraKit.eigh_pullback!(zero(A), A, (D, V), (ΔDtrunc, ΔVtrunc), r)
+            dA2 = MatrixAlgebraKit.eigh_trunc_pullback!(zero(A), A, (Dtrunc, Vtrunc), (ΔDtrunc, ΔVtrunc))
+            @test isapprox(dA1, dA2; atol = atol, rtol = rtol)
         end
         truncalg = TruncatedAlgorithm(alg, trunctol(; atol = maximum(abs, Ddiag) / 2))
         r = MatrixAlgebraKit.findtruncated(Ddiag, truncalg.trunc)
+        Dtrunc = Diagonal(diagview(D)[r])
+        Vtrunc = V[:, r]
+        ΔDtrunc = Diagonal(diagview(ΔD2)[r])
+        ΔVtrunc = ΔV[:, r]
         test_rrule(
             copy_eigh_trunc, A, truncalg ⊢ NoTangent();
             output_tangent = (ΔD2[r, r], ΔV[:, r]),
             atol = atol, rtol = rtol
         )
+        dA1 = MatrixAlgebraKit.eigh_pullback!(zero(A), A, (D, V), (ΔDtrunc, ΔVtrunc), r)
+        dA2 = MatrixAlgebraKit.eigh_trunc_pullback!(zero(A), A, (Dtrunc, Vtrunc), (ΔDtrunc, ΔVtrunc))
+        @test isapprox(dA1, dA2; atol = atol, rtol = rtol)
     end
     # Zygote part
     config = Zygote.ZygoteRuleConfig()
@@ -393,19 +407,37 @@ end
             for r in 1:4:minmn
                 truncalg = TruncatedAlgorithm(alg, truncrank(r))
                 r = MatrixAlgebraKit.findtruncated(diagview(S), truncalg.trunc)
+                Strunc = Diagonal(diagview(S)[r])
+                Utrunc = U[:, r]
+                Vᴴtrunc = Vᴴ[r, :]
+                ΔStrunc = Diagonal(diagview(ΔS2)[r])
+                ΔUtrunc = ΔU[:, r]
+                ΔVᴴtrunc = ΔVᴴ[r, :]
                 test_rrule(
                     copy_svd_trunc, A, truncalg ⊢ NoTangent();
-                    output_tangent = (ΔU[:, r], ΔS[r, r], ΔVᴴ[r, :]),
+                    output_tangent = (ΔUtrunc, ΔStrunc, ΔVᴴtrunc),
                     atol = atol, rtol = rtol
                 )
+                dA1 = MatrixAlgebraKit.svd_pullback!(zero(A), A, (U, S, Vᴴ), (ΔUtrunc, ΔStrunc, ΔVᴴtrunc), r)
+                dA2 = MatrixAlgebraKit.svd_trunc_pullback!(zero(A), A, (Utrunc, Strunc, Vᴴtrunc), (ΔUtrunc, ΔStrunc, ΔVᴴtrunc))
+                @test isapprox(dA1, dA2; atol = atol, rtol = rtol)
             end
             truncalg = TruncatedAlgorithm(alg, trunctol(atol = S[1, 1] / 2))
             r = MatrixAlgebraKit.findtruncated(diagview(S), truncalg.trunc)
+            Strunc = Diagonal(diagview(S)[r])
+            Utrunc = U[:, r]
+            Vᴴtrunc = Vᴴ[r, :]
+            ΔStrunc = Diagonal(diagview(ΔS2)[r])
+            ΔUtrunc = ΔU[:, r]
+            ΔVᴴtrunc = ΔVᴴ[r, :]
             test_rrule(
                 copy_svd_trunc, A, truncalg ⊢ NoTangent();
                 output_tangent = (ΔU[:, r], ΔS[r, r], ΔVᴴ[r, :]),
                 atol = atol, rtol = rtol
             )
+            dA1 = MatrixAlgebraKit.svd_pullback!(zero(A), A, (U, S, Vᴴ), (ΔUtrunc, ΔStrunc, ΔVᴴtrunc), r)
+            dA2 = MatrixAlgebraKit.svd_trunc_pullback!(zero(A), A, (Utrunc, Strunc, Vᴴtrunc), (ΔUtrunc, ΔStrunc, ΔVᴴtrunc))
+            @test isapprox(dA1, dA2; atol = atol, rtol = rtol)
         end
         # Zygote part
         config = Zygote.ZygoteRuleConfig()

--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -6,7 +6,7 @@ using ChainRulesCore, ChainRulesTestUtils, Zygote
 using MatrixAlgebraKit: diagview, TruncatedAlgorithm, PolarViaSVD
 using LinearAlgebra: UpperTriangular, Diagonal, Hermitian, mul!
 
-function remove_svdgauge_depence!(
+function remove_svdgauge_dependence!(
         ΔU, ΔVᴴ, U, S, Vᴴ;
         degeneracy_atol = MatrixAlgebraKit.default_pullback_gaugetol(S)
     )
@@ -16,7 +16,7 @@ function remove_svdgauge_depence!(
     mul!(ΔU, U, gaugepart, -1, 1)
     return ΔU, ΔVᴴ
 end
-function remove_eiggauge_depence!(
+function remove_eiggauge_dependence!(
         ΔV, D, V;
         degeneracy_atol = MatrixAlgebraKit.default_pullback_gaugetol(D)
     )
@@ -25,7 +25,7 @@ function remove_eiggauge_depence!(
     mul!(ΔV, V / (V' * V), gaugepart, -1, 1)
     return ΔV
 end
-function remove_eighgauge_depence!(
+function remove_eighgauge_dependence!(
         ΔV, D, V;
         degeneracy_atol = MatrixAlgebraKit.default_pullback_gaugetol(D)
     )
@@ -253,7 +253,7 @@ end
     A = randn(rng, T, m, m)
     D, V = eig_full(A)
     ΔV = randn(rng, complex(T), m, m)
-    ΔV = remove_eiggauge_depence!(ΔV, D, V; degeneracy_atol = atol)
+    ΔV = remove_eiggauge_dependence!(ΔV, D, V; degeneracy_atol = atol)
     ΔD = randn(rng, complex(T), m, m)
     ΔD2 = Diagonal(randn(rng, complex(T), m))
     for alg in (LAPACK_Simple(), LAPACK_Expert())
@@ -295,7 +295,7 @@ end
     D, V = eigh_full(A)
     Ddiag = diagview(D)
     ΔV = randn(rng, T, m, m)
-    ΔV = remove_eighgauge_depence!(ΔV, D, V; degeneracy_atol = atol)
+    ΔV = remove_eighgauge_dependence!(ΔV, D, V; degeneracy_atol = atol)
     ΔD = randn(rng, real(T), m, m)
     ΔD2 = Diagonal(randn(rng, real(T), m))
     for alg in (
@@ -380,7 +380,7 @@ end
         ΔS = randn(rng, real(T), minmn, minmn)
         ΔS2 = Diagonal(randn(rng, real(T), minmn))
         ΔVᴴ = randn(rng, T, minmn, n)
-        ΔU, ΔVᴴ = remove_svdgauge_depence!(ΔU, ΔVᴴ, U, S, Vᴴ; degeneracy_atol = atol)
+        ΔU, ΔVᴴ = remove_svdgauge_dependence!(ΔU, ΔVᴴ, U, S, Vᴴ; degeneracy_atol = atol)
         for alg in (LAPACK_QRIteration(), LAPACK_DivideAndConquer())
             test_rrule(
                 copy_svd_compact, A, alg ⊢ NoTangent();

--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -42,7 +42,7 @@ precision(::Type{<:Union{Float64, Complex{Float64}}}) = sqrt(eps(Float64))
 for f in
     (
         :qr_compact, :qr_full, :qr_null, :lq_compact, :lq_full, :lq_null,
-        :eig_full, :eigh_full, :eigh_trunc, :svd_compact, :svd_trunc,
+        :eig_full, :eig_trunc, :eigh_full, :eigh_trunc, :svd_compact, :svd_trunc,
         :left_polar, :right_polar,
     )
     copy_f = Symbol(:copy_, f)
@@ -252,6 +252,7 @@ end
     atol = rtol = m * m * precision(T)
     A = randn(rng, T, m, m)
     D, V = eig_full(A)
+    Ddiag = diagview(D)
     ΔV = randn(rng, complex(T), m, m)
     ΔV = remove_eiggauge_dependence!(ΔV, D, V; degeneracy_atol = atol)
     ΔD = randn(rng, complex(T), m, m)
@@ -265,6 +266,36 @@ end
             copy_eig_full, A, alg ⊢ NoTangent();
             output_tangent = (ΔD2, ΔV), atol = atol, rtol = rtol
         )
+        for r in 1:4:m
+            truncalg = TruncatedAlgorithm(alg, truncrank(r; by = abs))
+            ind = MatrixAlgebraKit.findtruncated(Ddiag, truncalg.trunc)
+            Dtrunc = Diagonal(diagview(D)[ind])
+            Vtrunc = V[:, ind]
+            ΔDtrunc = Diagonal(diagview(ΔD2)[ind])
+            ΔVtrunc = ΔV[:, ind]
+            test_rrule(
+                copy_eig_trunc, A, truncalg ⊢ NoTangent();
+                output_tangent = (ΔDtrunc, ΔVtrunc),
+                atol = atol, rtol = rtol
+            )
+            dA1 = MatrixAlgebraKit.eig_pullback!(zero(A), A, (D, V), (ΔDtrunc, ΔVtrunc), ind)
+            dA2 = MatrixAlgebraKit.eig_trunc_pullback!(zero(A), A, (Dtrunc, Vtrunc), (ΔDtrunc, ΔVtrunc))
+            @test isapprox(dA1, dA2; atol = atol, rtol = rtol)
+        end
+        truncalg = TruncatedAlgorithm(alg, truncrank(5; by = real))
+        ind = MatrixAlgebraKit.findtruncated(Ddiag, truncalg.trunc)
+        Dtrunc = Diagonal(Ddiag[ind])
+        Vtrunc = V[:, ind]
+        ΔDtrunc = Diagonal(diagview(ΔD2)[ind])
+        ΔVtrunc = ΔV[:, ind]
+        test_rrule(
+            copy_eig_trunc, A, truncalg ⊢ NoTangent();
+            output_tangent = (ΔDtrunc, ΔVtrunc),
+            atol = atol, rtol = rtol
+        )
+        dA1 = MatrixAlgebraKit.eig_pullback!(zero(A), A, (D, V), (ΔDtrunc, ΔVtrunc), ind)
+        dA2 = MatrixAlgebraKit.eig_trunc_pullback!(zero(A), A, (Dtrunc, Vtrunc), (ΔDtrunc, ΔVtrunc))
+        @test isapprox(dA1, dA2; atol = atol, rtol = rtol)
     end
     # Zygote part
     config = Zygote.ZygoteRuleConfig()
@@ -313,32 +344,32 @@ end
         )
         for r in 1:4:m
             truncalg = TruncatedAlgorithm(alg, truncrank(r; by = abs))
-            r = MatrixAlgebraKit.findtruncated(Ddiag, truncalg.trunc)
-            Dtrunc = Diagonal(diagview(D)[r])
-            Vtrunc = V[:, r]
-            ΔDtrunc = Diagonal(diagview(ΔD2)[r])
-            ΔVtrunc = ΔV[:, r]
+            ind = MatrixAlgebraKit.findtruncated(Ddiag, truncalg.trunc)
+            Dtrunc = Diagonal(diagview(D)[ind])
+            Vtrunc = V[:, ind]
+            ΔDtrunc = Diagonal(diagview(ΔD2)[ind])
+            ΔVtrunc = ΔV[:, ind]
             test_rrule(
                 copy_eigh_trunc, A, truncalg ⊢ NoTangent();
-                output_tangent = (ΔD2[r, r], ΔV[:, r]),
+                output_tangent = (ΔDtrunc, ΔVtrunc),
                 atol = atol, rtol = rtol
             )
-            dA1 = MatrixAlgebraKit.eigh_pullback!(zero(A), A, (D, V), (ΔDtrunc, ΔVtrunc), r)
+            dA1 = MatrixAlgebraKit.eigh_pullback!(zero(A), A, (D, V), (ΔDtrunc, ΔVtrunc), ind)
             dA2 = MatrixAlgebraKit.eigh_trunc_pullback!(zero(A), A, (Dtrunc, Vtrunc), (ΔDtrunc, ΔVtrunc))
             @test isapprox(dA1, dA2; atol = atol, rtol = rtol)
         end
         truncalg = TruncatedAlgorithm(alg, trunctol(; atol = maximum(abs, Ddiag) / 2))
-        r = MatrixAlgebraKit.findtruncated(Ddiag, truncalg.trunc)
-        Dtrunc = Diagonal(diagview(D)[r])
-        Vtrunc = V[:, r]
-        ΔDtrunc = Diagonal(diagview(ΔD2)[r])
-        ΔVtrunc = ΔV[:, r]
+        ind = MatrixAlgebraKit.findtruncated(Ddiag, truncalg.trunc)
+        Dtrunc = Diagonal(diagview(D)[ind])
+        Vtrunc = V[:, ind]
+        ΔDtrunc = Diagonal(diagview(ΔD2)[ind])
+        ΔVtrunc = ΔV[:, ind]
         test_rrule(
             copy_eigh_trunc, A, truncalg ⊢ NoTangent();
-            output_tangent = (ΔD2[r, r], ΔV[:, r]),
+            output_tangent = (ΔDtrunc, ΔVtrunc),
             atol = atol, rtol = rtol
         )
-        dA1 = MatrixAlgebraKit.eigh_pullback!(zero(A), A, (D, V), (ΔDtrunc, ΔVtrunc), r)
+        dA1 = MatrixAlgebraKit.eigh_pullback!(zero(A), A, (D, V), (ΔDtrunc, ΔVtrunc), ind)
         dA2 = MatrixAlgebraKit.eigh_trunc_pullback!(zero(A), A, (Dtrunc, Vtrunc), (ΔDtrunc, ΔVtrunc))
         @test isapprox(dA1, dA2; atol = atol, rtol = rtol)
     end
@@ -364,20 +395,20 @@ end
     eigh_trunc2(A; kwargs...) = eigh_trunc(Matrix(Hermitian(A)); kwargs...)
     for r in 1:4:m
         trunc = truncrank(r; by = real)
-        r = MatrixAlgebraKit.findtruncated(Ddiag, trunc)
+        ind = MatrixAlgebraKit.findtruncated(Ddiag, trunc)
         test_rrule(
             config, eigh_trunc2, A;
             fkwargs = (; trunc = trunc),
-            output_tangent = (ΔD[r, r], ΔV[:, r]),
+            output_tangent = (ΔD[ind, ind], ΔV[:, ind]),
             atol = atol, rtol = rtol, rrule_f = rrule_via_ad, check_inferred = false
         )
     end
     trunc = trunctol(; rtol = 1 / 2)
-    r = MatrixAlgebraKit.findtruncated(Ddiag, trunc)
+    ind = MatrixAlgebraKit.findtruncated(Ddiag, trunc)
     test_rrule(
         config, eigh_trunc2, A;
         fkwargs = (; trunc = trunc),
-        output_tangent = (ΔD[r, r], ΔV[:, r]),
+        output_tangent = (ΔD[ind, ind], ΔV[:, ind]),
         atol = atol, rtol = rtol, rrule_f = rrule_via_ad, check_inferred = false
     )
 end
@@ -406,36 +437,36 @@ end
             )
             for r in 1:4:minmn
                 truncalg = TruncatedAlgorithm(alg, truncrank(r))
-                r = MatrixAlgebraKit.findtruncated(diagview(S), truncalg.trunc)
-                Strunc = Diagonal(diagview(S)[r])
-                Utrunc = U[:, r]
-                Vᴴtrunc = Vᴴ[r, :]
-                ΔStrunc = Diagonal(diagview(ΔS2)[r])
-                ΔUtrunc = ΔU[:, r]
-                ΔVᴴtrunc = ΔVᴴ[r, :]
+                ind = MatrixAlgebraKit.findtruncated(diagview(S), truncalg.trunc)
+                Strunc = Diagonal(diagview(S)[ind])
+                Utrunc = U[:, ind]
+                Vᴴtrunc = Vᴴ[ind, :]
+                ΔStrunc = Diagonal(diagview(ΔS2)[ind])
+                ΔUtrunc = ΔU[:, ind]
+                ΔVᴴtrunc = ΔVᴴ[ind, :]
                 test_rrule(
                     copy_svd_trunc, A, truncalg ⊢ NoTangent();
                     output_tangent = (ΔUtrunc, ΔStrunc, ΔVᴴtrunc),
                     atol = atol, rtol = rtol
                 )
-                dA1 = MatrixAlgebraKit.svd_pullback!(zero(A), A, (U, S, Vᴴ), (ΔUtrunc, ΔStrunc, ΔVᴴtrunc), r)
+                dA1 = MatrixAlgebraKit.svd_pullback!(zero(A), A, (U, S, Vᴴ), (ΔUtrunc, ΔStrunc, ΔVᴴtrunc), ind)
                 dA2 = MatrixAlgebraKit.svd_trunc_pullback!(zero(A), A, (Utrunc, Strunc, Vᴴtrunc), (ΔUtrunc, ΔStrunc, ΔVᴴtrunc))
                 @test isapprox(dA1, dA2; atol = atol, rtol = rtol)
             end
             truncalg = TruncatedAlgorithm(alg, trunctol(atol = S[1, 1] / 2))
-            r = MatrixAlgebraKit.findtruncated(diagview(S), truncalg.trunc)
-            Strunc = Diagonal(diagview(S)[r])
-            Utrunc = U[:, r]
-            Vᴴtrunc = Vᴴ[r, :]
-            ΔStrunc = Diagonal(diagview(ΔS2)[r])
-            ΔUtrunc = ΔU[:, r]
-            ΔVᴴtrunc = ΔVᴴ[r, :]
+            ind = MatrixAlgebraKit.findtruncated(diagview(S), truncalg.trunc)
+            Strunc = Diagonal(diagview(S)[ind])
+            Utrunc = U[:, ind]
+            Vᴴtrunc = Vᴴ[ind, :]
+            ΔStrunc = Diagonal(diagview(ΔS2)[ind])
+            ΔUtrunc = ΔU[:, ind]
+            ΔVᴴtrunc = ΔVᴴ[ind, :]
             test_rrule(
                 copy_svd_trunc, A, truncalg ⊢ NoTangent();
-                output_tangent = (ΔU[:, r], ΔS[r, r], ΔVᴴ[r, :]),
+                output_tangent = (ΔUtrunc, ΔStrunc, ΔVᴴtrunc),
                 atol = atol, rtol = rtol
             )
-            dA1 = MatrixAlgebraKit.svd_pullback!(zero(A), A, (U, S, Vᴴ), (ΔUtrunc, ΔStrunc, ΔVᴴtrunc), r)
+            dA1 = MatrixAlgebraKit.svd_pullback!(zero(A), A, (U, S, Vᴴ), (ΔUtrunc, ΔStrunc, ΔVᴴtrunc), ind)
             dA2 = MatrixAlgebraKit.svd_trunc_pullback!(zero(A), A, (Utrunc, Strunc, Vᴴtrunc), (ΔUtrunc, ΔStrunc, ΔVᴴtrunc))
             @test isapprox(dA1, dA2; atol = atol, rtol = rtol)
         end
@@ -453,20 +484,20 @@ end
         )
         for r in 1:4:minmn
             trunc = truncrank(r)
-            r = MatrixAlgebraKit.findtruncated(diagview(S), trunc)
+            ind = MatrixAlgebraKit.findtruncated(diagview(S), trunc)
             test_rrule(
                 config, svd_trunc, A;
                 fkwargs = (; trunc = trunc),
-                output_tangent = (ΔU[:, r], ΔS[r, r], ΔVᴴ[r, :]),
+                output_tangent = (ΔU[:, ind], ΔS[ind, ind], ΔVᴴ[ind, :]),
                 atol = atol, rtol = rtol, rrule_f = rrule_via_ad, check_inferred = false
             )
         end
         trunc = trunctol(; atol = S[1, 1] / 2)
-        r = MatrixAlgebraKit.findtruncated(diagview(S), trunc)
+        ind = MatrixAlgebraKit.findtruncated(diagview(S), trunc)
         test_rrule(
             config, svd_trunc, A;
             fkwargs = (; trunc = trunc),
-            output_tangent = (ΔU[:, r], ΔS[r, r], ΔVᴴ[r, :]),
+            output_tangent = (ΔU[:, ind], ΔS[ind, ind], ΔVᴴ[ind, :]),
             atol = atol, rtol = rtol, rrule_f = rrule_via_ad, check_inferred = false
         )
     end


### PR DESCRIPTION
A first attempt at generalizing the `eig`, `eigh` and `svd` pullback rules so that they can also be used in the case of truncated methods with `TruncatedAlgorithm`, i.e. where first the full decomposition is computed. This was already supported for `svd`, but with the implicit assumption that the singular values/vectors kept were always the first ones.

This clearly needs additional tests, especially for the `eig` and `eigh` methods where such a sorted truncation order is definitely not guaranteed. 

Alternatively, I can also write an implementation that does not use the full decomposition, and solves the problem in terms of Sylvester equations with the original matrix. That might actually more generic. In particular, I am also thinking about randomized SVD, where one would not have the full decomposition available (and for which the current rules would thus be wrong or failing).