### PR TITLE
More consistent API for when to have `_full`, `_compact`, ...

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MatrixAlgebraKit"
 uuid = "6c742aac-3347-4629-af66-fc926824e5e4"
 authors = ["Jutho <jutho.haegeman@ugent.be> and contributors"]
-version = "0.4.1"
+version = "0.5.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/ext/MatrixAlgebraKitChainRulesCoreExt.jl
+++ b/ext/MatrixAlgebraKitChainRulesCoreExt.jl
@@ -25,7 +25,7 @@ for qr_f in (:qr_compact, :qr_full)
             QR = $(qr_f!)(Ac, QR, alg)
             function qr_pullback(ΔQR)
                 ΔA = zero(A)
-                MatrixAlgebraKit.qr_compact_pullback!(ΔA, A, QR, unthunk.(ΔQR))
+                MatrixAlgebraKit.qr_pullback!(ΔA, A, QR, unthunk.(ΔQR))
                 return NoTangent(), ΔA, ZeroTangent(), NoTangent()
             end
             function qr_pullback(::Tuple{ZeroTangent, ZeroTangent}) # is this extra definition useful?
@@ -46,7 +46,7 @@ function ChainRulesCore.rrule(::typeof(qr_null!), A::AbstractMatrix, N, alg)
         minmn = min(m, n)
         ΔQ = zero!(similar(A, (m, m)))
         view(ΔQ, 1:m, (minmn + 1):m) .= unthunk.(ΔN)
-        MatrixAlgebraKit.qr_compact_pullback!(ΔA, A, (Q, R), (ΔQ, ZeroTangent()))
+        MatrixAlgebraKit.qr_pullback!(ΔA, A, (Q, R), (ΔQ, ZeroTangent()))
         return NoTangent(), ΔA, ZeroTangent(), NoTangent()
     end
     function qr_null_pullback(::ZeroTangent) # is this extra definition useful?
@@ -63,7 +63,7 @@ for lq_f in (:lq_compact, :lq_full)
             LQ = $(lq_f!)(Ac, LQ, alg)
             function lq_pullback(ΔLQ)
                 ΔA = zero(A)
-                MatrixAlgebraKit.lq_compact_pullback!(ΔA, A, LQ, unthunk.(ΔLQ))
+                MatrixAlgebraKit.lq_pullback!(ΔA, A, LQ, unthunk.(ΔLQ))
                 return NoTangent(), ΔA, ZeroTangent(), NoTangent()
             end
             function lq_pullback(::Tuple{ZeroTangent, ZeroTangent}) # is this extra definition useful?
@@ -84,7 +84,7 @@ function ChainRulesCore.rrule(::typeof(lq_null!), A::AbstractMatrix, Nᴴ, alg)
         minmn = min(m, n)
         ΔQ = zero!(similar(A, (n, n)))
         view(ΔQ, (minmn + 1):n, 1:n) .= unthunk.(ΔNᴴ)
-        MatrixAlgebraKit.lq_compact_pullback!(ΔA, A, (L, Q), (ZeroTangent(), ΔQ))
+        MatrixAlgebraKit.lq_pullback!(ΔA, A, (L, Q), (ZeroTangent(), ΔQ))
         return NoTangent(), ΔA, ZeroTangent(), NoTangent()
     end
     function lq_null_pullback(::ZeroTangent) # is this extra definition useful?

--- a/src/MatrixAlgebraKit.jl
+++ b/src/MatrixAlgebraKit.jl
@@ -103,6 +103,4 @@ include("pullbacks/eigh.jl")
 include("pullbacks/svd.jl")
 include("pullbacks/polar.jl")
 
-include("deprecate.jl")
-
 end

--- a/src/MatrixAlgebraKit.jl
+++ b/src/MatrixAlgebraKit.jl
@@ -55,9 +55,9 @@ export notrunc, truncrank, trunctol, truncerror, truncfilter
     )
     eval(
         Expr(
-            :public, :qr_compact_pullback!, :lq_compact_pullback!, :left_polar_pullback!,
-            :right_polar_pullback!, :eig_pullback!, :eig_trunc_pullback!, :eigh_pullback!,
-            :eigh_trunc_pullback!, :svd_pullback!, :svd_trunc_pullback!
+            :public, :qr_pullback!, :lq_pullback!, :svd_pullback!, :svd_trunc_pullback!,
+            :eig_pullback!, :eig_trunc_pullback!, :eigh_pullback!, :eigh_trunc_pullback!,
+            :left_polar_pullback!, :right_polar_pullback!
         )
     )
 end
@@ -102,5 +102,7 @@ include("pullbacks/eig.jl")
 include("pullbacks/eigh.jl")
 include("pullbacks/svd.jl")
 include("pullbacks/polar.jl")
+
+include("deprecate.jl")
 
 end

--- a/src/common/regularinv.jl
+++ b/src/common/regularinv.jl
@@ -21,7 +21,7 @@ function inv_regularized(
         A::AbstractMatrix, tol = defaulttol(A); isposdef = isposdef(A), kwargs...
     )
     if isposdef
-        D, V = eigh(A; kwargs...)
+        D, V = eigh_full(A; kwargs...)
         Dinvsqrt = Diagonal(sqrt.(inv_regularized.(D.diag, tol)))
         VDinvsqrt = rmul!(V, Dinvsqrt)
         return VDinvsqrt * VDinvsqrt'
@@ -38,7 +38,7 @@ function sylvester_regularized(
         ishermitian = ishermitian(A) && ishermitian(B), kwargs...
     )
     if ishermitian
-        D, U = eigh(A; kwargs...)
+        D, U = eigh_full(A; kwargs...)
         UdCU = U' * B * U
         UdCU .*= inv_regularized.(D.diag .+ transpose(D.diag), tol)
         C = U * UdCU * U'

--- a/src/deprecate.jl
+++ b/src/deprecate.jl
@@ -1,2 +1,0 @@
-Base.@deprecate qr_compact_pullback!(args...) qr_pullback!(args...) false
-Base.@deprecate lq_compact_pullback!(args...) lq_pullback!(args...) false

--- a/src/deprecate.jl
+++ b/src/deprecate.jl
@@ -1,0 +1,2 @@
+Base.@deprecate qr_compact_pullback!(args...) qr_pullback!(args...) false
+Base.@deprecate lq_compact_pullback!(args...) lq_pullback!(args...) false

--- a/src/interface/eig.jl
+++ b/src/interface/eig.jl
@@ -1,6 +1,5 @@
 # Eig functions
 # -------------
-
 # TODO: kwargs for sorting eigenvalues?
 
 docs_eig_note = """
@@ -9,7 +8,6 @@ and therefore will always return complex eigenvalues and eigenvectors. For the r
 eigenvalue decomposition of symmetric or hermitian operators, see [`eigh_full`](@ref).
 """
 
-# TODO: do we need "full"?
 """
     eig_full(A; kwargs...) -> D, V
     eig_full(A, alg::AbstractAlgorithm) -> D, V

--- a/src/interface/eigh.jl
+++ b/src/interface/eigh.jl
@@ -1,13 +1,3 @@
-# Eigh API
-# --------
-# TODO: export? or not export but mark as public ?
-function eigh!(A::AbstractMatrix, args...; kwargs...)
-    return eigh_full!(A, args...; kwargs...)
-end
-function eigh(A::AbstractMatrix, args...; kwargs...)
-    return eigh_full(A, args...; kwargs...)
-end
-
 # Eigh functions
 # --------------
 # TODO: kwargs for sorting eigenvalues?
@@ -18,7 +8,6 @@ and therefore will retain the `eltype` of the input for the eigenvalues and eige
 For generic eigenvalue decompositions, see [`eig_full`](@ref).
 """
 
-# TODO: do we need "full"?
 """
     eigh_full(A; kwargs...) -> D, V
     eigh_full(A, alg::AbstractAlgorithm) -> D, V

--- a/src/interface/gen_eig.jl
+++ b/src/interface/gen_eig.jl
@@ -1,6 +1,5 @@
 # Gen Eig functions
 # -------------
-
 # TODO: kwargs for sorting eigenvalues?
 
 docs_gen_eig_note = """

--- a/src/interface/orthnull.jl
+++ b/src/interface/orthnull.jl
@@ -1,21 +1,3 @@
-# Simplified API
-# --------------
-function orth(A::AbstractMatrix; kwargs...)
-    return left_orth(A; kwargs...)
-end
-function null(A::AbstractMatrix; kwargs...)
-    return adjoint(right_null(A; kwargs...))
-end
-
-# TODO: do we need an advanced interface for the simplified API
-function orth!(A::AbstractMatrix, args...; kwargs...)
-    return left_orth!(A, args...; kwargs...)
-end
-
-function null!(A::AbstractMatrix, args...; kwargs...)
-    return right_null!(A, args...; kwargs...)
-end
-
 # Orth functions
 # --------------
 """

--- a/src/interface/polar.jl
+++ b/src/interface/polar.jl
@@ -1,12 +1,3 @@
-# Polar API
-# ---------
-function polar!(A::AbstractMatrix, args...; kwargs...)
-    return left_polar!(A, args...; kwargs...)
-end
-function polar(A::AbstractMatrix, args...; kwargs...)
-    return left_polar(A, args...; kwargs...)
-end
-
 # Polar functions
 # ---------------
 """

--- a/src/interface/schur.jl
+++ b/src/interface/schur.jl
@@ -1,13 +1,3 @@
-# Schur API
-# ---------
-# TODO: export? or not export but mark as public ?
-function schur!(A::AbstractMatrix, args...; kwargs...)
-    return schur_full!(A, args...; kwargs...)
-end
-function schur(A::AbstractMatrix, args...; kwargs...)
-    return schur_full(A, args...; kwargs...)
-end
-
 # Schur functions
 # -------------
 """

--- a/src/interface/svd.jl
+++ b/src/interface/svd.jl
@@ -1,13 +1,3 @@
-# SVD API
-# -------
-# TODO: export? or not export but mark as public ?
-function svd!(A::AbstractMatrix, args...; kwargs...)
-    return svd_compact!(A, args...; kwargs...)
-end
-function svd(A::AbstractMatrix, args...; kwargs...)
-    return svd_compact(A, args...; kwargs...)
-end
-
 # SVD functions
 # -------------
 """

--- a/src/pullbacks/lq.jl
+++ b/src/pullbacks/lq.jl
@@ -1,9 +1,9 @@
 """
-    lq_compact_pullback!(
+    lq_pullback!(
         ΔA, A, LQ, ΔLQ;
-        tol::Real=default_pullback_gaugetol(LQ[1]),
-        rank_atol::Real=tol,
-        gauge_atol::Real=tol
+        tol::Real = default_pullback_gaugetol(LQ[1]),
+        rank_atol::Real = tol,
+        gauge_atol::Real = tol
     )
 
 Adds the pullback from the LQ decomposition of `A` to `ΔA` given the output `LQ` and
@@ -16,7 +16,7 @@ well-defined, and also the adjoint variables `ΔL` and `ΔQ` should have nonzero
 in the first `r` columns and rows respectively. If nonzero values in the remaining columns
 or rows exceed `gauge_atol`, a warning will be printed.
 """
-function lq_compact_pullback!(
+function lq_pullback!(
         ΔA::AbstractMatrix, A, LQ, ΔLQ;
         tol::Real = default_pullback_gaugetol(LQ[1]),
         rank_atol::Real = tol,

--- a/src/pullbacks/qr.jl
+++ b/src/pullbacks/qr.jl
@@ -1,9 +1,9 @@
 """
-    qr_compact_pullback!(
+    qr_pullback!(
         ΔA, A, QR, ΔQR;
-        tol::Real=default_pullback_gaugetol(QR[2]),
-        rank_atol::Real=tol,
-        gauge_atol::Real=tol
+        tol::Real = default_pullback_gaugetol(QR[2]),
+        rank_atol::Real = tol,
+        gauge_atol::Real = tol
     )
 
 Adds the pullback from the QR decomposition of `A` to `ΔA` given the output `QR` and
@@ -16,7 +16,7 @@ and also the adjoint variables `ΔQ` and `ΔR` should have nonzero values only i
 `r` columns and rows respectively. If nonzero values in the remaining columns or rows exceed
 `gauge_atol`, a warning will be printed.
 """
-function qr_compact_pullback!(
+function qr_pullback!(
         ΔA::AbstractMatrix, A, QR, ΔQR;
         tol::Real = default_pullback_gaugetol(QR[2]),
         rank_atol::Real = tol,


### PR DESCRIPTION
This PR replaces `qr_compact_pullback!` (`lq_compact_pullback!`) with `qr_pullback!` (`lq_pullback!`) since these methods also work for the full case.

Additionally I removed some unused and unexported API that were remnants of old code.
I also fixed the formatting in some of the docstrings.