### PR TITLE
Ensure no sharing of data in LQ gauge fixing

### DIFF
--- a/src/implementations/lq.jl
+++ b/src/implementations/lq.jl
@@ -164,9 +164,10 @@ function lq_householder!(
     end
 
     if computeL
-        L̃ = lowertriangular!(view(A, axes(L)...))
-        positive && gaugefix!(lq_householder!, L̃, Q, diagview(A))
-        copyto!(L, L̃)
+        # we need to first copy then gaugefix - avoiding aliasing between L and Ld for broadcast
+        Ld = diagview(A)
+        copyto!(L, lowertriangular!(view(A, axes(L)...)))
+        positive && gaugefix!(lq_householder!, L, Q, Ld)
     else
         gaugefix!(lq_householder!, nothing, Q, diagview(A))
     end


### PR DESCRIPTION
This fixes #218.

Somehow this slipped through the cracks, as I already addressed this issue for QR (https://github.com/QuantumKitHub/MatrixAlgebraKit.jl/blob/a53006eec4d889cbe9a8f19fe8699ab0761bcc33/src/implementations/qr.jl#L178-L182) but forgot to also add it in LQ.
The issue being that `L .*= sign_safe.(diagview(L))` does not give correct results since `L` and `diagview(L)` share data in a non-trivial way.

Interestingly, broadcasting Base `Array` and views thereof detect this and make preventive copies, while `JLArray` does not have this behavior.
(I'm guessing there is some `dataids` overload missing or something for that to work):

```julia
julia> A = -jl(ones(3, 3))
3×3 JLArray{Float64, 2}:
 -1.0  -1.0  -1.0
 -1.0  -1.0  -1.0
 -1.0  -1.0  -1.0

julia> A .*= sign.(view(A, 1:4:9))
3×3 JLArray{Float64, 2}:
 1.0  -1.0  -1.0
 1.0   1.0  -1.0
 1.0   1.0   1.0

julia> B = -ones(3, 3)
3×3 Matrix{Float64}:
 -1.0  -1.0  -1.0
 -1.0  -1.0  -1.0
 -1.0  -1.0  -1.0

julia> B .*= sign.(view(B, 1:4:9))
3×3 Matrix{Float64}:
 1.0  1.0  1.0
 1.0  1.0  1.0
 1.0  1.0  1.0
```

In any case, this fix should now ensure correct results for JLArray's and one fewer allocation for regular `Array`s.