### PR TITLE
feat: Gaussian sketching + sketched SVD

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ authors = ["Jutho Haegeman <jutho.haegeman@ugent.be>, Lukas Devos, Katharine Hya
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [weakdeps]
 AMDGPU = "21141c5a-9bdb-4563-92ae-f87d6854732e"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -53,6 +53,7 @@ makedocs(;
             "user_interface/decompositions.md",
             "user_interface/algorithms.md",
             "user_interface/truncations.md",
+            "user_interface/sketching.md",
             "user_interface/properties.md",
             "user_interface/matrix_functions.md",
         ],

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -22,9 +22,13 @@ When releasing a new version, move the "Unreleased" changes to a new version sec
 
 ### Added
 
+- Randomized sketching API: new `SketchedAlgorithm` wrapper, `SketchingStrategy` supertype with the `GaussianSketching` strategy, and standalone `left_sketch` / `right_sketch` (plus bang variants) entry points for low-rank factorizations. `svd_trunc` / `svd_trunc!` / `svd_trunc_no_error` accept a new `sketch =` keyword that mirrors the existing `trunc =` pattern. The CUDA extension routes `SketchedAlgorithm(; driver = CUSOLVER())` to cuSOLVER's fused `gesvdr` kernel ([#225](https://github.com/QuantumKitHub/MatrixAlgebraKit.jl/pull/225)). See [Sketching](@ref) for details.
+
 ### Changed
 
 ### Deprecated
+
+- `CUSOLVER_Randomized` is deprecated in favour of `SketchedAlgorithm(; driver = CUSOLVER())` or the new `sketch =` keyword on `svd_trunc`. Calls using `CUSOLVER_Randomized` now emit a deprecation warning at algorithm selection and are forwarded to the new pipeline ([#225](https://github.com/QuantumKitHub/MatrixAlgebraKit.jl/pull/225)).
 
 ### Removed
 

--- a/docs/src/dev_interface.md
+++ b/docs/src/dev_interface.md
@@ -12,4 +12,5 @@ MatrixAlgebraKit.default_algorithm
 MatrixAlgebraKit.select_algorithm
 MatrixAlgebraKit.findtruncated
 MatrixAlgebraKit.findtruncated_svd
+MatrixAlgebraKit.select_sketching
 ```

--- a/docs/src/user_interface/algorithms.md
+++ b/docs/src/user_interface/algorithms.md
@@ -98,6 +98,23 @@ They all accept an optional `driver` keyword to select the computational backend
 
 For full docstring details on each algorithm type, see the corresponding section in [Decompositions](@ref).
 
+### Algorithm Wrappers
+
+In addition to the terminal algorithms above, MatrixAlgebraKit provides algorithm *wrappers* that compose a terminal algorithm with additional behaviour rather than computing a factorization themselves.
+Their `alg` field is one of the algorithms in the table above; the wrapper adds either a post-truncation step or a sketching step (or both).
+
+| Wrapper | Applicable decompositions | Key keyword arguments |
+|:--------|:--------------------------|:----------------------|
+| [`TruncatedAlgorithm`](@ref) | `svd_trunc`, `eigh_trunc`, `eig_trunc` | `alg`, `trunc` |
+| [`SketchedAlgorithm`](@ref) | `svd_trunc` | `sketch`, `trunc`, `alg`, `driver` |
+
+```@docs; canonical=false
+MatrixAlgebraKit.TruncatedAlgorithm
+MatrixAlgebraKit.SketchedAlgorithm
+```
+
+The corresponding truncated-decomposition functions ([`svd_trunc`](@ref), [`eigh_trunc`](@ref), [`eig_trunc`](@ref)) also accept `trunc =` and (for SVD) `sketch =` keyword arguments that construct the appropriate wrapper automatically; see [Truncations](@ref) and [Sketching](@ref) for the full interface.
+
 ## [Driver Selection](@id sec_driverselection)
 
 !!! note "Expert use case"

--- a/docs/src/user_interface/decompositions.md
+++ b/docs/src/user_interface/decompositions.md
@@ -140,6 +140,8 @@ It is also possible to compute the singular values only, using the [`svd_vals`](
 This then returns a vector of the values on the diagonal of `Σ`.
 
 Finally, we also support computing a partial or truncated SVD, using the [`svd_trunc`](@ref) function.
+To control the behavior of the truncation, we refer to [Truncations](@ref) for more information.
+Furthermore, for large matrices with rapidly-decaying spectra, the truncated SVD can additionally be computed via randomized sketching; see [Sketching](@ref).
 
 ```@docs; canonical=false
 svd_full

--- a/docs/src/user_interface/sketching.md
+++ b/docs/src/user_interface/sketching.md
@@ -1,0 +1,152 @@
+```@meta
+CurrentModule = MatrixAlgebraKit
+CollapsedDocStrings = true
+```
+
+# Sketching
+
+*Sketching* methods project a large matrix onto a low-dimensional subspace before any expensive dense factorization is performed.
+The result is an approximate low-rank decomposition that can be substantially cheaper than the corresponding full decomposition, depending on the quality of the sketch and the spectrum of the original matrix.
+
+This page first describes how to compute a sketch as a standalone operation, then how to plug a sketch into a partial decomposition such as a truncated SVD.
+
+## Standalone Sketches
+
+The basic sketching primitives are [`left_sketch`](@ref) and [`right_sketch`](@ref) (with their bang counterparts).
+They return an isometric range/co-range factor together with a corresponding core matrix, independent of any subsequent decomposition.
+
+[`left_sketch`](@ref) computes an isometric matrix `Q` whose column span approximates the range of `A`, together with the core factor `B = Q' * A`:
+
+```jldoctest sketching; output=false
+using MatrixAlgebraKit
+using MatrixAlgebraKit: diagview
+using LinearAlgebra: norm
+using Random: MersenneTwister
+
+# A rank-3 matrix
+A = randn(MersenneTwister(0), 8, 3) * randn(MersenneTwister(1), 3, 6);
+
+Q, B = left_sketch(A; howmany = 3, rng = MersenneTwister(42));
+isisometric(Q) && A ≈ Q * B
+
+# output
+true
+```
+
+[`right_sketch`](@ref) is the dual operation, returning a right-isometric matrix `Pᴴ` (orthonormal rows) and core factor `B = A * Pᴴ'`:
+
+```jldoctest sketching; output=false
+B, Pᴴ = right_sketch(A; howmany = 3, rng = MersenneTwister(42));
+isisometric(Pᴴ') && A ≈ B * Pᴴ
+
+# output
+true
+```
+
+These functions follow the same conventions as other decompositions: `left_sketch!` / `right_sketch!` may destroy the input, and the bang forms optionally accept pre-allocated output tuples.
+
+```@docs; canonical=false
+left_sketch
+left_sketch!
+right_sketch
+right_sketch!
+```
+
+## Available Sketching Strategies
+
+The keyword arguments accepted by `left_sketch` / `right_sketch` are forwarded to the default sketching strategy for the input type (currently [`GaussianSketching`](@ref) for all `AbstractMatrix`).
+For full control, construct a strategy directly and pass it as the second positional argument:
+
+```jldoctest sketching; output=false
+Q, B = left_sketch(A, GaussianSketching(3; numiter = 4, rng = MersenneTwister(42)));
+A ≈ Q * B
+
+# output
+true
+```
+
+```@docs; canonical=false
+GaussianSketching
+SketchingStrategy
+```
+
+The `numiter` keyword controls the number of power iterations.
+The first iteration is the initial sketch; additional iterations apply `A * A'` to improve accuracy on slowly-decaying spectra at the cost of two extra matrix multiplications per iteration.
+The default `numiter = 2` is a conservative choice; values of 4–5 often improve accuracy significantly when the singular values decay slowly.
+
+!!! note "Additional strategies"
+    [`GaussianSketching`](@ref) is currently the only built-in [`SketchingStrategy`](@ref).
+    Additional strategies (for example, structured or subsampled sketches) may be added in the future; the interface is deliberately written against the abstract [`SketchingStrategy`](@ref) supertype so that new strategies plug in without changes to the downstream decomposition code.
+
+## Sketched Partial Decompositions
+
+A sketch can be combined with a small dense decomposition of the core factor to obtain an approximate partial decomposition of the original matrix.
+At present, this is supported for the truncated SVD via [`svd_trunc`](@ref) / [`svd_trunc!`](@ref) / [`svd_trunc_no_error`](@ref).
+
+!!! note "Not yet supported"
+    Sketched variants of [`eigh_trunc`](@ref) and [`eig_trunc`](@ref) are natural extensions of the same machinery but are not implemented yet.
+    The [`SketchedAlgorithm`](@ref) wrapper and the `sketch =` keyword are currently only accepted by the truncated SVD functions.
+
+There are two equivalent ways to request a sketched truncated SVD, paralleling the two-form syntax used for [Truncations](@ref).
+
+### 1. Using the `sketch` keyword with a `NamedTuple`
+
+The simplest form is to pass a `NamedTuple` of sketch parameters together with the desired truncation:
+
+```jldoctest sketching; output=false
+U, S, Vᴴ, ϵ = svd_trunc(A;
+    sketch = (; howmany = 3, rng = MersenneTwister(42)),
+    trunc = truncrank(3),
+);
+size(diagview(S), 1) == 3 && A ≈ U * S * Vᴴ
+
+# output
+true
+```
+
+The `NamedTuple` keywords are forwarded to the default sketching strategy for the input type, exactly as for `left_sketch` above.
+
+### 2. Using an explicit `SketchedAlgorithm`
+
+For full control, construct a [`SketchedAlgorithm`](@ref) value directly and pass it as the `alg` argument:
+
+```jldoctest sketching; output=false
+alg = SketchedAlgorithm(;
+    sketch = GaussianSketching(3; rng = MersenneTwister(42)),
+    trunc = truncrank(3),
+);
+U, S, Vᴴ, ϵ = svd_trunc(A, alg);
+A ≈ U * S * Vᴴ
+
+# output
+true
+```
+
+When an `alg::SketchedAlgorithm` is supplied, the `sketch` and `trunc` keywords cannot also be specified at the call site; doing so raises `ArgumentError`.
+All configuration must instead live inside the algorithm constructor.
+
+### The `SketchedAlgorithm` Wrapper
+
+```@docs; canonical=false
+SketchedAlgorithm
+```
+
+`SketchedAlgorithm` differs from [`TruncatedAlgorithm`](@ref) in that it is *self-truncating*: the sketch step itself produces a small dense problem of size `sketch.howmany`, and any further `trunc` is applied to the result of the inner factorization rather than to a full dense decomposition.
+
+The `driver` field selects the backend implementing the sketched pipeline:
+
+- `Native()` (the default for CPU array types) runs the generic *sketch-then-decompose* pipeline using the standard [`left_sketch!`](@ref) / [`right_sketch!`](@ref) building blocks followed by the inner `alg`.
+- `CUSOLVER()` (the default for CUDA array types, with the appropriate extension loaded) dispatches to cuSOLVER's fused `gesvdr` kernel, which performs the sketch and the small SVD in a single device call.
+
+To force a particular driver, set it explicitly:
+
+```julia
+using MatrixAlgebraKit: CUSOLVER  # driver types are not exported by default
+
+alg = SketchedAlgorithm(;
+    sketch = GaussianSketching(k; numiter = 4),
+    trunc = truncrank(k),
+    driver = CUSOLVER(),
+)
+U, S, Vᴴ, ϵ = svd_trunc(A_cuda, alg)
+```

--- a/ext/MatrixAlgebraKitCUDAExt/MatrixAlgebraKitCUDAExt.jl
+++ b/ext/MatrixAlgebraKitCUDAExt/MatrixAlgebraKitCUDAExt.jl
@@ -4,11 +4,12 @@ using MatrixAlgebraKit
 using MatrixAlgebraKit: @algdef, Algorithm, check_input
 using MatrixAlgebraKit: one!, zero!, uppertriangular!, lowertriangular!
 using MatrixAlgebraKit: diagview, sign_safe
-using MatrixAlgebraKit: CUSOLVER, LQViaTransposedQR, TruncationByValue, AbstractAlgorithm
+using MatrixAlgebraKit: CUSOLVER, LQViaTransposedQR, TruncationByValue, TruncationByOrder, AbstractAlgorithm
+using MatrixAlgebraKit: GaussianSketching, SketchingStrategy, SketchedAlgorithm
 using MatrixAlgebraKit: default_qr_algorithm, default_lq_algorithm, default_svd_algorithm, default_eig_algorithm, default_eigh_algorithm
 import MatrixAlgebraKit: geqrf!, ungqr!, unmqr!, gesvd!, gesvdp!, gesvdr!, gesvdj!
 import MatrixAlgebraKit: heevj!, heevd!, geev!
-import MatrixAlgebraKit: _gpu_Xgesvdr!, _sylvester, svd_rank
+import MatrixAlgebraKit: _sylvester, svd_rank
 using CUDA, CUDA.cuBLAS
 using CUDA: i32
 using LinearAlgebra
@@ -17,6 +18,7 @@ using LinearAlgebra: BlasFloat
 include("yacusolver.jl")
 
 MatrixAlgebraKit.default_driver(::Type{TA}) where {TA <: StridedCuVecOrMat{<:BlasFloat}} = CUSOLVER()
+MatrixAlgebraKit.default_driver(::Type{<:SketchedAlgorithm}, ::Type{TA}) where {TA <: StridedCuVecOrMat{<:BlasFloat}} = CUSOLVER()
 
 function MatrixAlgebraKit.default_svd_algorithm(::Type{T}; kwargs...) where {T <: StridedCuVecOrMat{<:BlasFloat}}
     return QRIteration(; kwargs...)
@@ -50,8 +52,31 @@ end
 gesvdp!(::CUSOLVER, A::StridedCuMatrix, S::StridedCuVector, U::StridedCuMatrix, Vᴴ::StridedCuMatrix; kwargs...) =
     YACUSOLVER.gesvdp!(A, S, U, Vᴴ; kwargs...)
 
-_gpu_Xgesvdr!(A::StridedCuMatrix, S::StridedCuVector, U::StridedCuMatrix, Vᴴ::StridedCuMatrix; kwargs...) =
-    YACUSOLVER.gesvdr!(A, S, U, Vᴴ; kwargs...)
+# Sketched SVD via cuSOLVER's gesvdr kernel
+function gesvdr!(
+        ::CUSOLVER, A::StridedCuMatrix, S, U::StridedCuMatrix, Vᴴ::StridedCuMatrix;
+        sketch::GaussianSketching, trunc::TruncationByOrder, alg::AbstractAlgorithm = DefaultAlgorithm()
+    )
+    isempty(A) && return U, S, Vᴴ
+    m, n = size(A); minmn = min(m, n)
+    k = trunc.howmany
+    1 ≤ k ≤ minmn ||
+        throw(ArgumentError("trunc.howmany=$k must satisfy 1 ≤ k ≤ min(size(A))=$minmn"))
+    p = sketch.howmany - k
+    p ≥ 0 || throw(
+        ArgumentError(
+            "sketch.howmany=$(sketch.howmany) must be ≥ trunc.howmany=$k"
+        )
+    )
+    p = min(p, minmn - k - 1)
+    niters = sketch.numiter - 1
+
+    Uk = view(U, :, 1:k)
+    Vᴴk = view(Vᴴ, 1:k, :)
+    Sk = view(diagview(S), 1:k)
+    YACUSOLVER.gesvdr!(A, Sk, Uk, Vᴴk; k, p, niters)
+    return Uk, S, Vᴴk
+end
 
 geev!(::CUSOLVER, A::StridedCuMatrix, Dd::StridedCuVector, V::StridedCuMatrix) =
     YACUSOLVER.Xgeev!(A, Dd, V)

--- a/ext/MatrixAlgebraKitCUDAExt/MatrixAlgebraKitCUDAExt.jl
+++ b/ext/MatrixAlgebraKitCUDAExt/MatrixAlgebraKitCUDAExt.jl
@@ -52,30 +52,27 @@ end
 gesvdp!(::CUSOLVER, A::StridedCuMatrix, S::StridedCuVector, U::StridedCuMatrix, Vᴴ::StridedCuMatrix; kwargs...) =
     YACUSOLVER.gesvdp!(A, S, U, Vᴴ; kwargs...)
 
-# Sketched SVD via cuSOLVER's gesvdr kernel
+# Sketched SVD via cuSOLVER's gesvdr kernel.
+# The full m×m / n×n shapes of U / Vᴴ allow YACUSOLVER.gesvdr! to reuse them as cuSOLVER workspace.
+# `alg` is accepted but unused: cuSOLVER's gesvdr fuses the inner SVD itself.
 function gesvdr!(
         ::CUSOLVER, A::StridedCuMatrix, S, U::StridedCuMatrix, Vᴴ::StridedCuMatrix;
         sketch::GaussianSketching, trunc::TruncationByOrder, alg::AbstractAlgorithm = DefaultAlgorithm()
     )
     isempty(A) && return U, S, Vᴴ
-    m, n = size(A); minmn = min(m, n)
-    k = trunc.howmany
-    1 ≤ k ≤ minmn ||
-        throw(ArgumentError("trunc.howmany=$k must satisfy 1 ≤ k ≤ min(size(A))=$minmn"))
-    p = sketch.howmany - k
-    p ≥ 0 || throw(
-        ArgumentError(
-            "sketch.howmany=$(sketch.howmany) must be ≥ trunc.howmany=$k"
-        )
-    )
-    p = min(p, minmn - k - 1)
-    niters = sketch.numiter - 1
+    m, n = size(A)
+    sketch_amount = min(sketch.howmany, m, n)
+    k = min(trunc.howmany, m, n)
+    p = max(sketch_amount - k, 0)
+    numiter = sketch.numiter
 
-    Uk = view(U, :, 1:k)
-    Vᴴk = view(Vᴴ, 1:k, :)
-    Sk = view(diagview(S), 1:k)
-    YACUSOLVER.gesvdr!(A, Sk, Uk, Vᴴk; k, p, niters)
-    return Uk, S, Vᴴk
+    V = Vᴴ # gesvdr returns V, but this has to be the same size so we will use this as workspace
+
+    YACUSOLVER.gesvdr!(A, diagview(S), U, V; k, p, numiter)
+
+    # Truncate requires Vᴴ, so we adjoint here
+    USVᴴtrunc, _ = MatrixAlgebraKit.truncate(MatrixAlgebraKit.svd_trunc!, (U, S, V'), trunc)
+    return USVᴴtrunc
 end
 
 geev!(::CUSOLVER, A::StridedCuMatrix, Dd::StridedCuVector, V::StridedCuMatrix) =

--- a/ext/MatrixAlgebraKitCUDAExt/yacusolver.jl
+++ b/ext/MatrixAlgebraKitCUDAExt/yacusolver.jl
@@ -266,32 +266,44 @@ for (bname, fname, elty, relty) in
     end
 end
 
-# Wrapper for randomized SVD
+# Wrapper for randomized SVD.
+# Caller must supply full-size buffers: U is (m, m) and Vᴴ is (n, n); both are reused
+# directly as cuSOLVER's workspace, and Vᴴ is converted in place from V to Vᴴ on the
+# leading k rows after cuSOLVER returns.
+# !!! Warning: this function takes in/returns V instead of Vᴴ
 function gesvdr!(
         A::StridedCuMatrix{T},
         S::StridedCuVector = similar(A, real(T), min(size(A)...)),
-        U::StridedCuMatrix{T} = similar(A, T, size(A, 1), min(size(A)...)),
-        Vᴴ::StridedCuMatrix{T} = similar(A, T, min(size(A)...), size(A, 2));
+        U::StridedCuMatrix{T} = similar(A, T, size(A, 1), size(A, 1)),
+        V::StridedCuMatrix{T} = similar(A, T, size(A, 2), size(A, 2));
         k::Int = length(S),
         p::Int = min(size(A)...) - k - 1,
-        niters::Int = 1
+        numiter::Int = 1,
     ) where {T <: BlasFloat}
-    chkstride1(A, U, S, Vᴴ)
+    chkstride1(A, U, S, V)
     m, n = size(A)
     minmn = min(m, n)
-    jobu = length(U) == 0 ? 'N' : 'S'
-    jobv = length(Vᴴ) == 0 ? 'N' : 'S'
     R = eltype(S)
-    k < minmn || throw(DimensionMismatch("length of S ($k) must be less than the smaller dimension of A ($minmn)"))
-    k + p < minmn || throw(DimensionMismatch("length of S ($k) plus oversampling ($p) must be less than the smaller dimension of A ($minmn)"))
     R == real(T) ||
         throw(ArgumentError("S does not have the matching real `eltype` of A"))
+    length(S) == minmn ||
+        throw(DimensionMismatch("length of S ($(length(S))) must equal min(size(A)) = $minmn"))
+    size(U) == (m, m) ||
+        throw(DimensionMismatch("U must have shape (m, m) = ($m, $m); got $(size(U))"))
+    size(V) == (n, n) ||
+        throw(DimensionMismatch("V must have shape (n, n) = ($n, $n); got $(size(V))"))
+    k < minmn ||
+        throw(DimensionMismatch("rank k ($k) must be less than min(size(A)) = $minmn"))
+    k + p < minmn ||
+        throw(DimensionMismatch("k + p ($(k + p)) must be less than min(size(A)) = $minmn"))
 
-    Ṽ = similar(Vᴴ, (n, n))
-    Ũ = (size(U) == (m, m)) ? U : similar(U, (m, m))
+    isempty(A) && return S, U, V
+
+    jobu = 'S'
+    jobv = 'S'
     lda = max(1, stride(A, 2))
-    ldu = max(1, stride(Ũ, 2))
-    ldv = max(1, stride(Ṽ, 2))
+    ldu = max(1, stride(U, 2))
+    ldv = max(1, stride(V, 2))
     params = cuSOLVER.CuSolverParameters()
     dh = cuSOLVER.dense_handle()
 
@@ -299,8 +311,8 @@ function gesvdr!(
         out_cpu = Ref{Csize_t}(0)
         out_gpu = Ref{Csize_t}(0)
         cuSOLVER.cusolverDnXgesvdr_bufferSize(
-            dh, params, jobu, jobv, m, n, k, p, niters,
-            T, A, lda, R, S, T, Ũ, ldu, T, Ṽ, ldv,
+            dh, params, jobu, jobv, m, n, k, p, numiter,
+            T, A, lda, R, S, T, U, ldu, T, V, ldv,
             T, out_gpu, out_cpu
         )
 
@@ -311,8 +323,8 @@ function gesvdr!(
         bufferSize()...
     ) do buffer_gpu, buffer_cpu
         return cuSOLVER.cusolverDnXgesvdr(
-            dh, params, jobu, jobv, m, n, k, p, niters,
-            T, A, lda, R, S, T, Ũ, ldu, T, Ṽ, ldv,
+            dh, params, jobu, jobv, m, n, k, p, numiter,
+            T, A, lda, R, S, T, U, ldu, T, V, ldv,
             T, buffer_gpu, sizeof(buffer_gpu),
             buffer_cpu, sizeof(buffer_cpu),
             dh.info
@@ -321,16 +333,8 @@ function gesvdr!(
 
     flag = @allowscalar dh.info[1]
     cuSOLVER.chklapackerror(BlasInt(flag))
-    if Ũ !== U && length(U) > 0
-        U .= view(Ũ, 1:m, 1:size(U, 2))
-    end
-    if length(Vᴴ) > 0
-        Vᴴ .= view(Ṽ', 1:size(Vᴴ, 1), 1:n)
-    end
-    Ũ !== U && CUDA.unsafe_free!(Ũ)
-    CUDA.unsafe_free!(Ṽ)
 
-    return S, U, Vᴴ
+    return S, U, V
 end
 
 # Wrapper for general eigensolver

--- a/src/MatrixAlgebraKit.jl
+++ b/src/MatrixAlgebraKit.jl
@@ -9,6 +9,8 @@ using LinearAlgebra: Diagonal, diag, diagind, isdiag
 using LinearAlgebra: UpperTriangular, LowerTriangular
 using LinearAlgebra: BlasFloat, BlasReal, BlasComplex, BlasInt
 
+using Random: Random
+
 export isisometric, isunitary, ishermitian, isantihermitian
 export diagview, diagonal
 
@@ -30,6 +32,8 @@ export left_polar, right_polar
 export left_polar!, right_polar!
 export left_orth, right_orth, left_null, right_null
 export left_orth!, right_orth!, left_null!, right_null!
+export left_sketch, right_sketch
+export left_sketch!, right_sketch!
 
 export Householder, Native_HouseholderQR, Native_HouseholderLQ
 export DivideAndConquer, SafeDivideAndConquer, QRIteration, Bisection, Jacobi, SVDViaPolar
@@ -49,6 +53,8 @@ export ROCSOLVER_HouseholderQR, ROCSOLVER_QRIteration, ROCSOLVER_Jacobi,
     ROCSOLVER_DivideAndConquer, ROCSOLVER_Bisection
 
 export notrunc, truncrank, trunctol, truncerror, truncfilter
+
+export SketchedAlgorithm, SketchingStrategy, GaussianSketching
 
 @static if VERSION >= v"1.11.0-DEV.469"
     eval(
@@ -101,6 +107,7 @@ include("interface/truncation.jl")
 include("interface/qr.jl")
 include("interface/lq.jl")
 include("interface/svd.jl")
+include("interface/sketching.jl")
 include("interface/eig.jl")
 include("interface/eigh.jl")
 include("interface/gen_eig.jl")
@@ -113,6 +120,7 @@ include("implementations/truncation.jl")
 include("implementations/qr.jl")
 include("implementations/lq.jl")
 include("implementations/svd.jl")
+include("implementations/sketching.jl")
 include("implementations/eig.jl")
 include("implementations/eigh.jl")
 include("implementations/gen_eig.jl")

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -356,17 +356,25 @@ struct TruncatedAlgorithm{A <: AbstractAlgorithm, T <: TruncationStrategy} <: Ab
 end
 
 """
-    SketchedAlgorithm(alg::AbstractAlgorithm, sketch::SketchingStrategy, trunc::TruncationStrategy)
+    SketchedAlgorithm(;
+        alg::AbstractAlgorithm, sketch::SketchingStrategy,
+        trunc::TruncationStrategy, driver::Driver = DefaultDriver()
+    )
 
 Generic wrapper type for self-truncating algorithms that produce an approximate low-rank
 factorization by first applying a sketching operation specified by `sketch`, then computing
 a small dense decomposition of the projected matrix using `alg`. The `driver` selects the
-backend (e.g. `DefaultDriver()`, `CUSOLVER()`).
+backend implementing the sketched factorization (e.g. `Native()` for the generic
+sketch-then-decompose pipeline, `CUSOLVER()` for the fused `gesvdr` kernel).
 """
-struct SketchedAlgorithm{A <: AbstractAlgorithm, S <: SketchingStrategy, T <: TruncationStrategy} <: AbstractAlgorithm
-    alg::A
+@kwdef struct SketchedAlgorithm{
+        A <: AbstractAlgorithm, S <: SketchingStrategy,
+        T <: TruncationStrategy, D <: Driver,
+    } <: AbstractAlgorithm
+    alg::A = DefaultAlgorithm()
     sketch::S
-    trunc::T
+    trunc::T = notrunc()
+    driver::D = DefaultDriver()
 end
 
 # utility conversion constructor

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -350,6 +350,9 @@ struct SketchedAlgorithm{A <: AbstractAlgorithm, S <: SketchingStrategy, T <: Tr
     trunc::T
 end
 
+# utility conversion constructor
+TruncatedAlgorithm(alg::SketchedAlgorithm) = TruncatedAlgorithm(alg.alg, alg.trunc)
+
 does_truncate(::TruncatedAlgorithm) = true
 does_truncate(::SketchedAlgorithm) = true
 

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -292,7 +292,26 @@ function select_null_truncation(trunc)
     elseif trunc isa TruncationStrategy
         return trunc
     else
-        return throw(ArgumentError("Unknown truncation strategy: $trunc"))
+        throw(ArgumentError("Unknown truncation strategy: $trunc"))
+    end
+end
+
+@doc """
+    MatrixAlgebraKit.select_sketching(A, sketch)
+
+Construct a [`SketchingStrategy`](@ref) for `A` from the given `NamedTuple` of keywords or input strategy `sketch`.
+""" select_sketching
+
+@inline select_sketching(A, sketch) = select_sketching(typeof(A), sketch)
+@inline function select_sketching(::Type{A}, sketch) where {A}
+    if isnothing(sketch)
+        return nothing
+    elseif sketch isa SketchingStrategy
+        return sketch
+    elseif sketch isa NamedTuple
+        return select_algorithm(left_sketch!, A; sketch...)
+    else
+        throw(ArgumentError("Unknown sketching strategy: $sketch"))
     end
 end
 
@@ -331,7 +350,7 @@ function truncate end
 Generic wrapper type for algorithms that consist of first using `alg`, followed by a
 truncation through `trunc`.
 """
-struct TruncatedAlgorithm{A, T} <: AbstractAlgorithm
+struct TruncatedAlgorithm{A <: AbstractAlgorithm, T <: TruncationStrategy} <: AbstractAlgorithm
     alg::A
     trunc::T
 end
@@ -356,10 +375,9 @@ TruncatedAlgorithm(alg::SketchedAlgorithm) = TruncatedAlgorithm(alg.alg, alg.tru
 does_truncate(::TruncatedAlgorithm) = true
 does_truncate(::SketchedAlgorithm) = true
 
-truncated_algorithm(alg::AbstractAlgorithm, trunc::TruncationStrategy) =
-    TruncatedAlgorithm(alg, trunc)
-truncated_algorithm(alg::AbstractAlgorithm, sketch::SketchingStrategy) =
-    SketchedAlgorithm(sketch, alg, DefaultDriver())
+truncated_algorithm(alg::AbstractAlgorithm, trunc::TruncationStrategy, sketch = nothing) =
+    isnothing(sketch) ? TruncatedAlgorithm(alg, trunc) : SketchedAlgorithm(; alg, sketch, trunc)
+
 
 # Utility macros
 # --------------

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -242,7 +242,7 @@ default_driver(::Type{TA}) where {TA <: YALAPACK.MaybeBlasVecOrMat} = LAPACK()
 """
     abstract type TruncationStrategy end
 
-Supertype to denote different strategies for truncated decompositions.
+Supertype to denote different strategies for truncated decompositions that are implemented via post-truncation.
 
 See also [`truncate`](@ref)
 """
@@ -593,7 +593,7 @@ macro check_size(x, sz, size = :size)
             szx = $size($x)
             $err = $msgstart * string(szx) * " instead of expected value " *
                 string($sz)
-            (szx == $sz)::Bool || throw(DimensionMismatch($err))
+            (szx == $sz) || throw(DimensionMismatch($err))
         end
     )
 end

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -242,11 +242,20 @@ default_driver(::Type{TA}) where {TA <: YALAPACK.MaybeBlasVecOrMat} = LAPACK()
 """
     abstract type TruncationStrategy end
 
-Supertype to denote different strategies for truncated decompositions that are implemented via post-truncation.
+Supertype to denote different strategies for truncated decompositions.
 
 See also [`truncate`](@ref)
 """
 abstract type TruncationStrategy end
+
+"""
+    abstract type SketchingStrategy <: AbstractAlgorithm end
+
+Supertype to denote different sketching strategies, used both as standalone algorithms for
+[`left_sketch!`](@ref) and [`right_sketch!`](@ref) and as the `sketch` field of a
+[`SketchedAlgorithm`](@ref) for self-truncating SVD.
+"""
+abstract type SketchingStrategy <: AbstractAlgorithm end
 
 @doc """
     MatrixAlgebraKit.select_truncation(trunc)
@@ -317,7 +326,7 @@ See also [`findtruncated`](@ref) and [`findtruncated_svd`](@ref) for determining
 function truncate end
 
 """
-    TruncatedAlgorithm(alg::AbstractAlgorithm, trunc::TruncationAlgorithm)
+    TruncatedAlgorithm(alg::AbstractAlgorithm, trunc::TruncationStrategy)
 
 Generic wrapper type for algorithms that consist of first using `alg`, followed by a
 truncation through `trunc`.
@@ -327,7 +336,27 @@ struct TruncatedAlgorithm{A, T} <: AbstractAlgorithm
     trunc::T
 end
 
+"""
+    SketchedAlgorithm(alg::AbstractAlgorithm, sketch::SketchingStrategy, trunc::TruncationStrategy)
+
+Generic wrapper type for self-truncating algorithms that produce an approximate low-rank
+factorization by first applying a sketching operation specified by `sketch`, then computing
+a small dense decomposition of the projected matrix using `alg`. The `driver` selects the
+backend (e.g. `DefaultDriver()`, `CUSOLVER()`).
+"""
+struct SketchedAlgorithm{A <: AbstractAlgorithm, S <: SketchingStrategy, T <: TruncationStrategy} <: AbstractAlgorithm
+    alg::A
+    sketch::S
+    trunc::T
+end
+
 does_truncate(::TruncatedAlgorithm) = true
+does_truncate(::SketchedAlgorithm) = true
+
+truncated_algorithm(alg::AbstractAlgorithm, trunc::TruncationStrategy) =
+    TruncatedAlgorithm(alg, trunc)
+truncated_algorithm(alg::AbstractAlgorithm, sketch::SketchingStrategy) =
+    SketchedAlgorithm(sketch, alg, DefaultDriver())
 
 # Utility macros
 # --------------
@@ -535,7 +564,7 @@ macro check_size(x, sz, size = :size)
             szx = $size($x)
             $err = $msgstart * string(szx) * " instead of expected value " *
                 string($sz)
-            szx == $sz || throw(DimensionMismatch($err))
+            (szx == $sz)::Bool || throw(DimensionMismatch($err))
         end
     )
 end

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -220,22 +220,36 @@ Driver to select GenericSchur.jl as the implementation strategy.
 struct GS <: Driver end
 
 # In order to avoid amibiguities, this method is implemented in a tiered way
-# default_driver(alg, A) -> default_driver(typeof(alg), typeof(A))
-# default_driver(Talg, TA) -> default_driver(TA)
+# default_driver(alg, A)   -> default_driver(typeof(alg), typeof(A))
+# default_driver(Talg, A)  -> default_driver(Talg, typeof(A))
+# default_driver(Talg, TA) -> default_driver(Talg, _unwrapped_array_type(TA)) | default_driver(TA)
+# default_driver(TA)       -> driver
 # This is to try and minimize ambiguity while allowing overloading at multiple levels
 @inline default_driver(alg::AbstractAlgorithm, A) = default_driver(typeof(alg), A isa Type ? A : typeof(A))
 @inline default_driver(::Type{Alg}, A) where {Alg <: AbstractAlgorithm} = default_driver(Alg, typeof(A))
-@inline default_driver(::Type{Alg}, ::Type{TA}) where {Alg <: AbstractAlgorithm, TA} = default_driver(TA)
+
+# Generic 2-arg fallback: if `TA` is a supported wrapper type, recurse on the
+# unwrapped storage type (so algorithm-specialized methods on the parent array
+# type still apply). Otherwise drop the algorithm and fall through to the
+# array-only dispatch.
+@inline function default_driver(::Type{Alg}, ::Type{TA}) where {Alg <: AbstractAlgorithm, TA <: AbstractArray}
+    UA = _unwrapped_array_type(TA)
+    return UA === TA ? default_driver(TA) : default_driver(Alg, UA)
+end
 
 # defaults
 default_driver(::Type{TA}) where {TA <: AbstractArray} = Native() # default fallback
 default_driver(::Type{TA}) where {TA <: YALAPACK.MaybeBlasVecOrMat} = LAPACK()
 
-# wrapper types
-@inline default_driver(::Type{Alg}, ::Type{<:SubArray{T, N, A}}) where {Alg <: AbstractAlgorithm, T, N, A} = default_driver(Alg, A)
-@inline default_driver(::Type{Alg}, ::Type{<:Base.ReshapedArray{T, N, A}}) where {Alg <: AbstractAlgorithm, T, N, A} = default_driver(Alg, A)
+# wrapper types (1-arg form, reached via the generic 2-arg fallback)
 @inline default_driver(::Type{<:SubArray{T, N, A}}) where {T, N, A} = default_driver(A)
 @inline default_driver(::Type{<:Base.ReshapedArray{T, N, A}}) where {T, N, A} = default_driver(A)
+
+# Internal helper: strip supported wrapper types to the underlying storage
+# array type. Add a new method here when introducing additional wrappers.
+@inline _unwrapped_array_type(::Type{TA}) where {TA <: AbstractArray} = TA
+@inline _unwrapped_array_type(::Type{<:SubArray{T, N, A}}) where {T, N, A} = _unwrapped_array_type(A)
+@inline _unwrapped_array_type(::Type{<:Base.ReshapedArray{T, N, A}}) where {T, N, A} = _unwrapped_array_type(A)
 
 # Truncation strategy
 # -------------------

--- a/src/implementations/orthnull.jl
+++ b/src/implementations/orthnull.jl
@@ -116,8 +116,8 @@ function right_null!(A, Nᴴ, alg::RightNullViaSVD{<:TruncatedAlgorithm})
     return Nᴴ
 end
 
-# randomized algorithms don't currently work for smallest values:
-left_null!(A, N, alg::LeftNullViaSVD{<:TruncatedAlgorithm{<:GPU_Randomized}}) =
+# randomized (sketched) algorithms don't currently work for smallest values:
+left_null!(A, N, alg::LeftNullViaSVD{<:SketchedAlgorithm}) =
     throw(ArgumentError("Randomized SVD ($alg) cannot be used for null spaces yet"))
-right_null!(A, Nᴴ, alg::RightNullViaSVD{<:TruncatedAlgorithm{<:GPU_Randomized}}) =
+right_null!(A, Nᴴ, alg::RightNullViaSVD{<:SketchedAlgorithm}) =
     throw(ArgumentError("Randomized SVD ($alg) cannot be used for null spaces yet"))

--- a/src/implementations/sketching.jl
+++ b/src/implementations/sketching.jl
@@ -1,0 +1,64 @@
+# Inputs / defaults / outputs
+# ---------------------------
+copy_input(::typeof(left_sketch), A) = A
+copy_input(::typeof(right_sketch), A) = A
+
+function initialize_output(::typeof(left_sketch!), A::AbstractMatrix, alg::GaussianSketching)
+    m, n = size(A)
+    k = min(alg.howmany, m, n)
+    T = float(eltype(A))
+    Q = similar(A, T, (m, k))
+    B = similar(A, T, (k, n))
+    return Q, B
+end
+function initialize_output(::typeof(right_sketch!), A::AbstractMatrix, alg::GaussianSketching)
+    return initialize_output(left_sketch!, A, alg)
+end
+
+function check_input(::typeof(left_sketch!), A::AbstractMatrix, (Q, B), alg::GaussianSketching)
+    m, n = size(A)
+    k = min(alg.howmany, m, n)
+    @assert Q isa AbstractMatrix
+    @check_size(Q, (m, k))
+    @check_scalar(Q, A, float)
+    @assert B isa AbstractMatrix
+    @check_size(B, (k, n))
+    @check_scalar(B, A, float)
+    return nothing
+end
+function check_input(::typeof(right_sketch!), A::AbstractMatrix, BPᴴ, alg::GaussianSketching)
+    check_input(left_sketch!, A, BPᴴ, alg)
+    return nothing
+end
+
+# Gaussian sketching, native implementation
+# -----------------------------------------
+function left_sketch!(A::AbstractMatrix, QB, alg::GaussianSketching)
+    check_input(left_sketch!, A, QB, alg)
+    Q, B = QB
+    Ω = Random.randn!(alg.rng, similar(Q, (size(A, 2), size(Q, 2))))
+    Y = A * Ω
+    R = similar(Y, (0, 0))
+    Q, _ = left_orth!(Y, (Q, R))
+    for _ in 2:alg.numiter
+        mul!(Ω, A', Q)
+        mul!(Y, A, Ω)
+        Q, _ = left_orth!(Y, (Q, R))
+    end
+    return Q, mul!(B, Q', A)
+end
+
+function right_sketch!(A::AbstractMatrix, BPᴴ, alg::GaussianSketching)
+    check_input(right_sketch!, A, BPᴴ, alg)
+    B, Pᴴ = BPᴴ
+    Ω = Random.randn!(alg.rng, similar(Pᴴ, (size(Pᴴ, 1), size(A, 1))))
+    Y = Ω * A
+    L = similar(Y, (0, 0))
+    _, Pᴴ = right_orth!(Y, (L, Pᴴ))
+    for _ in 2:alg.numiter
+        mul!(Ω, Pᴴ, A')
+        mul!(Y, Ω, A)
+        _, Pᴴ = right_orth!(Y, (L, Pᴴ))
+    end
+    return mul!(B, A, Pᴴ'), Pᴴ
+end

--- a/src/implementations/svd.jl
+++ b/src/implementations/svd.jl
@@ -308,26 +308,7 @@ check_input(::typeof(svd_trunc!), A::AbstractMatrix, USVᴴ, alg::SketchedAlgori
 
 function svd_trunc_no_error!(A::AbstractMatrix, (U, S, Vᴴ), alg::SketchedAlgorithm)
     check_input(svd_trunc_no_error!, A, (U, S, Vᴴ), alg)
-    m, n = size(A)
-    if m ≥ n
-        Q, B = left_sketch!(A, (U, Vᴴ), alg.sketch)
-        k = size(B, 1)
-        U′ = similar(B, (k, k))
-        Vᴴ′ = similar(B)
-        USVᴴ_inner = svd_compact!(B, (U′, S, Vᴴ′), alg.alg)
-        (Uout′, Sout, Vᴴout), _ = truncate(svd_trunc!, USVᴴ_inner, alg.trunc)
-        Uout = Q * Uout′
-    else
-        B, Pᴴ = right_sketch!(A, (U, Vᴴ), alg.sketch)
-        k = size(B, 2)
-        U′ = similar(B)
-        Vᴴ′ = similar(B, (k, k))
-        USVᴴ_inner = svd_compact!(B, (U′, S, Vᴴ′), alg.alg)
-        (Uout, Sout, Vᴴout′), _ = truncate(svd_trunc!, USVᴴ_inner, alg.trunc)
-        Vᴴout = Vᴴout′ * Pᴴ
-    end
-    get(alg.alg.kwargs, :fixgauge, true) && gaugefix!(svd_trunc!, Uout, Vᴴout)
-    return Uout, Sout, Vᴴout
+    return gesvdr!(alg.driver, A, S, U, Vᴴ; alg.sketch, alg.alg, alg.trunc)
 end
 
 function svd_trunc!(A::AbstractMatrix, USVᴴ, alg::SketchedAlgorithm)
@@ -335,6 +316,37 @@ function svd_trunc!(A::AbstractMatrix, USVᴴ, alg::SketchedAlgorithm)
     Na = norm(A)
     Ns = norm(S)
     return U, S, Vᴴ, sqrt(max(zero(Na), (Na + Ns) * (Na - Ns)))
+end
+
+# gesvdr! drivers
+# ---------------
+default_driver(::Type{<:SketchedAlgorithm}, ::Type{<:AbstractArray}) = Native()
+
+gesvdr!(::DefaultDriver, A, S, U, Vᴴ; kwargs...) =
+    gesvdr!(default_driver(SketchedAlgorithm, A), A, S, U, Vᴴ; kwargs...)
+
+function gesvdr!(
+        ::Native, A::AbstractMatrix, S, U, Vᴴ;
+        sketch::SketchingStrategy, alg::AbstractAlgorithm,
+        trunc::TruncationStrategy
+    )
+    m, n = size(A)
+    if m ≥ n
+        Q, B = left_sketch!(A, (U, Vᴴ), sketch)
+        k = size(B, 1)
+        U′ = similar(B, (k, k))
+        Vᴴ′ = similar(B)
+        Uout′, Sout, Vᴴout, _ = svd_trunc!(B, (U′, S, Vᴴ′), TruncatedAlgorithm(alg, trunc))
+        Uout = Q * Uout′
+    else
+        B, Pᴴ = right_sketch!(A, (U, Vᴴ), sketch)
+        k = size(B, 2)
+        U′ = similar(B)
+        Vᴴ′ = similar(B, (k, k))
+        Uout, Sout, Vᴴout′, _ = svd_trunc!(B, (U′, S, Vᴴ′), TruncatedAlgorithm(alg, trunc))
+        Vᴴout = Vᴴout′ * Pᴴ
+    end
+    return Uout, Sout, Vᴴout
 end
 
 # Deprecations
@@ -378,6 +390,40 @@ for (algtype, newtype, drivertype) in (
             svd_vals!(A, S, $newtype(; driver = $drivertype(), alg.kwargs...))
         )
     end
+end
+
+# CUSOLVER_Randomized → SketchedAlgorithm with driver = CUSOLVER()
+function _cusolver_randomized_to_sketched(alg::CUSOLVER_Randomized)
+    k = alg.kwargs.k
+    p = alg.kwargs.p
+    niters = alg.kwargs.niters
+    return SketchedAlgorithm(
+        QRIteration(),
+        GaussianSketching(k + p; numiter = niters + 1),
+        truncrank(k);
+        driver = CUSOLVER(),
+    )
+end
+
+for f! in (:svd_trunc!, :svd_trunc_no_error!)
+    @eval Base.@deprecate(
+        $f!(A::AbstractMatrix, USVᴴ, alg::CUSOLVER_Randomized),
+        $f!(A, USVᴴ, _cusolver_randomized_to_sketched(alg))
+    )
+end
+
+@inline function select_algorithm(::typeof(svd_trunc!), A, alg::CUSOLVER_Randomized; kwargs...)
+    Base.depwarn(
+        "`CUSOLVER_Randomized` is deprecated; use \
+         `SketchedAlgorithm(QRIteration(), GaussianSketching(k+p; numiter=niters+1), truncrank(k); driver=CUSOLVER())` instead.",
+        :select_algorithm,
+    )
+    isempty(kwargs) ||
+        throw(ArgumentError("Additional keyword arguments are not allowed when algorithm parameters are specified."))
+    return _cusolver_randomized_to_sketched(alg)
+end
+@inline function select_algorithm(::typeof(svd_trunc_no_error!), A, alg::CUSOLVER_Randomized; kwargs...)
+    return select_algorithm(svd_trunc!, A, alg; kwargs...)
 end
 
 # GLA_QRIteration SVD deprecations (eigh methods remain in the GLA extension)

--- a/src/implementations/svd.jl
+++ b/src/implementations/svd.jl
@@ -311,6 +311,36 @@ function svd_trunc_no_error!(A::AbstractMatrix, (U, S, Vᴴ), alg::SketchedAlgor
     return gesvdr!(alg.driver, A, S, U, Vᴴ; alg.sketch, alg.alg, alg.trunc)
 end
 
+# CUSOLVER's gesvdr kernel requires full U and Vᴴ
+function initialize_output(
+        ::typeof(svd_trunc_no_error!), A::AbstractMatrix,
+        alg::SketchedAlgorithm{<:AbstractAlgorithm, <:SketchingStrategy, <:TruncationStrategy, CUSOLVER},
+    )
+    m, n = size(A)
+    minmn = min(m, n)
+    T = float(eltype(A))
+    U = similar(A, T, (m, m))
+    S = Diagonal(similar(A, real(T), (minmn,)))
+    Vᴴ = similar(A, T, (n, n))
+    return (U, S, Vᴴ)
+end
+
+function check_input(
+        ::typeof(svd_trunc_no_error!), A::AbstractMatrix, (U, S, Vᴴ),
+        alg::SketchedAlgorithm{<:AbstractAlgorithm, <:SketchingStrategy, <:TruncationStrategy, CUSOLVER},
+    )
+    m, n = size(A)
+    minmn = min(m, n)
+    @assert U isa AbstractMatrix && S isa Diagonal && Vᴴ isa AbstractMatrix
+    @check_size(U, (m, m))
+    @check_scalar(U, A)
+    @check_size(S, (minmn, minmn))
+    @check_scalar(S, A, real)
+    @check_size(Vᴴ, (n, n))
+    @check_scalar(Vᴴ, A)
+    return nothing
+end
+
 function svd_trunc!(A::AbstractMatrix, USVᴴ, alg::SketchedAlgorithm)
     U, S, Vᴴ = svd_trunc_no_error!(A, USVᴴ, alg)
     Na = norm(A)
@@ -399,7 +429,7 @@ function _cusolver_randomized_to_sketched(alg::CUSOLVER_Randomized)
     niters = alg.kwargs.niters
     return SketchedAlgorithm(
         QRIteration(),
-        GaussianSketching(k + p; numiter = niters + 1),
+        GaussianSketching(k + p; numiter = niters),
         truncrank(k);
         driver = CUSOLVER(),
     )
@@ -415,7 +445,7 @@ end
 @inline function select_algorithm(::typeof(svd_trunc!), A, alg::CUSOLVER_Randomized; kwargs...)
     Base.depwarn(
         "`CUSOLVER_Randomized` is deprecated; use \
-         `SketchedAlgorithm(QRIteration(), GaussianSketching(k+p; numiter=niters+1), truncrank(k); driver=CUSOLVER())` instead.",
+         `SketchedAlgorithm(QRIteration(), GaussianSketching(k+p; numiter=niters), truncrank(k); driver=CUSOLVER())` instead.",
         :select_algorithm,
     )
     isempty(kwargs) ||

--- a/src/implementations/svd.jl
+++ b/src/implementations/svd.jl
@@ -285,66 +285,56 @@ function svd_vals!(A::AbstractMatrix, S, alg::DiagonalAlgorithm)
     return S
 end
 
-# GPU logic (randomized SVD - CUSOLVER_Randomized has no CPU analog, kept as-is)
-# ---------------------------------------------------------------------------------
+# Sketched Logic
+# --------------
+function initialize_output(::typeof(svd_trunc_no_error!), A::AbstractMatrix, alg::SketchedAlgorithm)
+    U, Vᴴ = initialize_output(left_sketch!, A, alg.sketch)
+    S = Diagonal(similar(U, real(eltype(U)), (size(U, 2),)))
+    return U, S, Vᴴ
+end
+initialize_output(::typeof(svd_trunc!), A::AbstractMatrix, alg::SketchedAlgorithm) =
+    initialize_output(svd_trunc_no_error!, A, alg)
 
-function check_input(
-        ::Union{typeof(svd_trunc!), typeof(svd_trunc_no_error!)}, A::AbstractMatrix, USVᴴ, alg::CUSOLVER_Randomized
-    )
-    m, n = size(A)
-    minmn = min(m, n)
-    U, S, Vᴴ = USVᴴ
+function check_input(::typeof(svd_trunc_no_error!), A::AbstractMatrix, (U, S, Vᴴ), alg::SketchedAlgorithm)
+    check_input(left_sketch!, A, (U, Vᴴ), alg.sketch)
     @assert U isa AbstractMatrix && S isa Diagonal && Vᴴ isa AbstractMatrix
-    @check_size(U, (m, m))
-    @check_scalar(U, A)
-    @check_size(S, (minmn, minmn))
-    @check_scalar(S, A, real)
-    @check_size(Vᴴ, (n, n))
-    @check_scalar(Vᴴ, A)
+    k = size(U, 2)
+    @check_size(S, (k, k))
+    @check_scalar(S, U, real)
     return nothing
 end
+check_input(::typeof(svd_trunc!), A::AbstractMatrix, USVᴴ, alg::SketchedAlgorithm) =
+    check_input(svd_trunc_no_error!, A, USVᴴ, alg)
 
-function initialize_output(
-        ::Union{typeof(svd_trunc!), typeof(svd_trunc_no_error!)}, A::AbstractMatrix, alg::TruncatedAlgorithm{<:CUSOLVER_Randomized}
-    )
+function svd_trunc_no_error!(A::AbstractMatrix, (U, S, Vᴴ), alg::SketchedAlgorithm)
+    check_input(svd_trunc_no_error!, A, (U, S, Vᴴ), alg)
     m, n = size(A)
-    minmn = min(m, n)
-    U = similar(A, (m, m))
-    S = Diagonal(similar(A, real(eltype(A)), (minmn,)))
-    Vᴴ = similar(A, (n, n))
-    return (U, S, Vᴴ)
+    if m ≥ n
+        Q, B = left_sketch!(A, (U, Vᴴ), alg.sketch)
+        k = size(B, 1)
+        U′ = similar(B, (k, k))
+        Vᴴ′ = similar(B)
+        USVᴴ_inner = svd_compact!(B, (U′, S, Vᴴ′), alg.alg)
+        (Uout′, Sout, Vᴴout), _ = truncate(svd_trunc!, USVᴴ_inner, alg.trunc)
+        Uout = Q * Uout′
+    else
+        B, Pᴴ = right_sketch!(A, (U, Vᴴ), alg.sketch)
+        k = size(B, 2)
+        U′ = similar(B)
+        Vᴴ′ = similar(B, (k, k))
+        USVᴴ_inner = svd_compact!(B, (U′, S, Vᴴ′), alg.alg)
+        (Uout, Sout, Vᴴout′), _ = truncate(svd_trunc!, USVᴴ_inner, alg.trunc)
+        Vᴴout = Vᴴout′ * Pᴴ
+    end
+    get(alg.alg.kwargs, :fixgauge, true) && gaugefix!(svd_trunc!, Uout, Vᴴout)
+    return Uout, Sout, Vᴴout
 end
 
-function _gpu_Xgesvdr!(
-        A::AbstractMatrix, S::AbstractVector, U::AbstractMatrix, Vᴴ::AbstractMatrix; kwargs...
-    )
-    throw(MethodError(_gpu_Xgesvdr!, (A, S, U, Vᴴ)))
-end
-
-function svd_trunc_no_error!(A::AbstractMatrix, USVᴴ, alg::TruncatedAlgorithm{<:GPU_Randomized})
-    U, S, Vᴴ = USVᴴ
-    check_input(svd_trunc_no_error!, A, (U, S, Vᴴ), alg.alg)
-    _gpu_Xgesvdr!(A, diagview(S), U, Vᴴ; alg.alg.kwargs...)
-
-    # TODO: make sure that truncation is based on maxrank, otherwise this might be wrong
-    (Utr, Str, Vᴴtr), _ = truncate(svd_trunc!, (U, S, Vᴴ), alg.trunc)
-
-    do_gauge_fix = get(alg.alg.kwargs, :fixgauge, default_fixgauge())::Bool
-    # the output matrices here are the same size as for svd_full!
-    do_gauge_fix && gaugefix!(svd_trunc!, Utr, Vᴴtr)
-
-    return Utr, Str, Vᴴtr
-end
-
-function svd_trunc!(A::AbstractMatrix, USVᴴ, alg::TruncatedAlgorithm{<:GPU_Randomized})
-    Utr, Str, Vᴴtr = svd_trunc_no_error!(A, USVᴴ, alg)
-    # normal `truncation_error!` does not work here since `S` is not the full singular value spectrum
-    normS = norm(diagview(Str))
-    normA = norm(A)
-    # equivalent to sqrt(normA^2 - normS^2)
-    # but may be more accurate
-    ϵ = sqrt((normA + normS) * abs(normA - normS))
-    return Utr, Str, Vᴴtr, ϵ
+function svd_trunc!(A::AbstractMatrix, USVᴴ, alg::SketchedAlgorithm)
+    U, S, Vᴴ = svd_trunc_no_error!(A, USVᴴ, alg)
+    Na = norm(A)
+    Ns = norm(S)
+    return U, S, Vᴴ, sqrt(max(zero(Na), (Na + Ns) * (Na - Ns)))
 end
 
 # Deprecations

--- a/src/interface/decompositions.jl
+++ b/src/interface/decompositions.jl
@@ -408,8 +408,6 @@ for more information.
 """
 @algdef CUSOLVER_Randomized
 
-does_truncate(::TruncatedAlgorithm{<:CUSOLVER_Randomized}) = true
-
 """
     CUSOLVER_Simple(; fixgauge = default_fixgauge())
 

--- a/src/interface/sketching.jl
+++ b/src/interface/sketching.jl
@@ -1,0 +1,89 @@
+# Gaussian sketching
+# ------------------
+"""
+    GaussianSketching(howmany; numiter, rng)
+
+Sketching strategy using a Gaussian random matrix with optional power iterations to improve
+accuracy on slowly-decaying spectra.
+
+## Fields
+- `howmany::Int`: number of singular values to compute.
+- `numiter::Int`: number of power iterations (`numiter ≥ 1`; the first counts as the initial
+  sketch).
+- `rng::AbstractRNG`: random number generator used to draw the Gaussian sketch matrix.
+"""
+struct GaussianSketching{RNG <: Random.AbstractRNG} <: SketchingStrategy
+    howmany::Int
+    numiter::Int
+    rng::RNG
+end
+
+function GaussianSketching(howmany::Integer; numiter::Integer = 2, rng::Random.AbstractRNG = Random.default_rng())
+    howmany ≥ 0 || throw(ArgumentError("howmany must be non-negative"))
+    numiter ≥ 1 || throw(ArgumentError("numiter must be at least 1 ($numiter)"))
+    return GaussianSketching{typeof(rng)}(howmany, numiter, rng)
+end
+
+# Entry points
+# ------------
+"""
+    left_sketch(A; howmany, kwargs...) -> Q, B
+    left_sketch(A, alg::AbstractAlgorithm) -> Q, B
+    left_sketch!(A, [QB]; howmany, kwargs...) -> Q, B
+    left_sketch!(A, [QB], alg::AbstractAlgorithm) -> Q, B
+
+Compute an isometric matrix `Q` (orthonormal columns) of size m×k, whose column span approximates the range of `A` of size m×n.
+Also create the core factor `B = Q' * A`.
+Here `k = howmany` is the sketch dimension.
+
+The keyword arguments construct a [`GaussianSketching`](@ref) strategy unless an explicit `alg::SketchingStrategy` is supplied.
+`howmany` is required.
+
+!!! note
+    The bang method `left_sketch!` optionally accepts the output matrices `Q, B` and possibly destroys the input matrix `A`.
+    Always use the return value of the function as it may not always be possible to use the provided `Q, B` as output.
+
+See also [`right_sketch(!)`](@ref right_sketch) and [`SketchedAlgorithm`](@ref).
+"""
+@functiondef left_sketch
+
+"""
+    right_sketch(A; howmany, kwargs...) -> B, Pᴴ
+    right_sketch(A, alg::AbstractAlgorithm) -> B, Pᴴ
+    right_sketch!(A, [BPᴴ]; howmany, kwargs...) -> B, Pᴴ
+    right_sketch!(A, [BPᴴ], alg::AbstractAlgorithm) -> B, Pᴴ
+
+Compute a right-isometric matrix `Pᴴ` (orthonormal rows) of size k×n, whose row span approximates the range of `A` of size m×n.
+Also create the core factor `B = A * Pᴴ'`
+Here `k = howmany` is the sketch dimension.
+
+The keyword arguments construct a [`GaussianSketching`](@ref) strategy unless an explicit `alg::SketchingStrategy` is supplied.
+`howmany` is required.
+
+!!! note
+    The bang method `right_sketch!` optionally accepts the output matrices `BPᴴ` and possibly destroys the input matrix `A`.
+    Always use the return value of the function as it may not always be possible to use the provided `BPᴴ` as output.
+
+See also [`left_sketch(!)`](@ref left_sketch) and [`SketchedAlgorithm`](@ref).
+"""
+@functiondef right_sketch
+
+# Algorithm selection
+# -------------------
+default_sketch_algorithm(A; kwargs...) = default_sketch_algorithm(typeof(A); kwargs...)
+default_sketch_algorithm(T::Type; kwargs...) = throw(MethodError(default_sketch_algorithm, (T,)))
+function default_sketch_algorithm(::Type{T}; howmany, kwargs...) where {T <: AbstractMatrix}
+    return GaussianSketching(howmany; kwargs...)
+end
+function default_sketch_algorithm(::Type{<:Base.ReshapedArray{T, N, A}}; kwargs...) where {T, N, A}
+    return default_sketch_algorithm(A; kwargs...)
+end
+function default_sketch_algorithm(::Type{<:SubArray{T, N, A}}; kwargs...) where {T, N, A}
+    return default_sketch_algorithm(A; kwargs...)
+end
+
+for f in (:left_sketch!, :right_sketch!)
+    @eval function default_algorithm(::typeof($f), ::Type{A}; kwargs...) where {A}
+        return default_sketch_algorithm(A; kwargs...)
+    end
+end

--- a/src/interface/svd.jl
+++ b/src/interface/svd.jl
@@ -179,23 +179,18 @@ for f in (:svd_full!, :svd_compact!, :svd_vals!)
 end
 
 for f in (:svd_trunc!, :svd_trunc_no_error!)
-    @eval function select_algorithm(::typeof($f), A, alg; trunc = nothing, kwargs...)
-        if alg isa TruncatedAlgorithm
+    @eval function select_algorithm(::typeof($f), A, alg; trunc = nothing, sketch = nothing, kwargs...)
+        if alg isa TruncatedAlgorithm || alg isa SketchedAlgorithm
             isnothing(trunc) ||
-                throw(ArgumentError("`trunc` can't be specified when `alg` is a `TruncatedAlgorithm`"))
-            return alg
-        elseif alg isa SketchedAlgorithm
-            isnothing(trunc) ||
-                throw(ArgumentError("`trunc` can't be specified when `alg` is a `SketchedAlgorithm`"))
+                throw(ArgumentError("`trunc` can't be specified when `alg` is a `TruncatedAlgorithm` or `SketchedAlgorithm`"))
+            isnothing(sketch) ||
+                throw(ArgumentError("`sketch` can't be specified when `alg` is a `TruncatedAlgorithm` or `SketchedAlgorithm`"))
             return alg
         else
             alg_svd = select_algorithm(svd_compact!, A, alg; kwargs...)
             trunc = select_truncation(trunc)
-            if trunc isa TruncationStrategy
-                return truncated_algorithm(alg_svd, trunc)
-            else
-                throw(ArgumentError("invalid truncation $trunc"))
-            end
+            sketch = select_sketching(A, sketch)
+            return truncated_algorithm(alg_svd, trunc, sketch)
         end
     end
 end

--- a/src/interface/svd.jl
+++ b/src/interface/svd.jl
@@ -184,9 +184,18 @@ for f in (:svd_trunc!, :svd_trunc_no_error!)
             isnothing(trunc) ||
                 throw(ArgumentError("`trunc` can't be specified when `alg` is a `TruncatedAlgorithm`"))
             return alg
+        elseif alg isa SketchedAlgorithm
+            isnothing(trunc) ||
+                throw(ArgumentError("`trunc` can't be specified when `alg` is a `SketchedAlgorithm`"))
+            return alg
         else
             alg_svd = select_algorithm(svd_compact!, A, alg; kwargs...)
-            return TruncatedAlgorithm(alg_svd, select_truncation(trunc))
+            trunc = select_truncation(trunc)
+            if trunc isa TruncationStrategy
+                return truncated_algorithm(alg_svd, trunc)
+            else
+                throw(ArgumentError("invalid truncation $trunc"))
+            end
         end
     end
 end

--- a/src/yalapack.jl
+++ b/src/yalapack.jl
@@ -2351,7 +2351,7 @@ for (gesvd, gesdd, gesvdx, gejsv, gesvj, elty, relty) in
                 throw(DimensionMismatch("length mismatch between A ($n) and S ($(length(S)))"))
 
             lda = max(1, stride(A, 2))
-            mv = Ref{BlasInt}() # unused
+            mv = Ref{BlasInt}(0) # unused by LAPACK when JOBV='V', but must satisfy MV ≥ 0 input check
             if jobv == 'V'
                 if U !== A
                     V = view(U, 1:n, 1:n) # use U as V storage

--- a/test/decompositions/svd.jl
+++ b/test/decompositions/svd.jl
@@ -18,15 +18,25 @@ is_buildkite = get(ENV, "BUILDKITE", "false") == "true"
 # CPU tests
 # ---------
 if !is_buildkite
-    # LAPACK algorithms:
-    for T in BLASFloats, m in (0, 54), n in (0, 37, m, 63)
+    @testset "LAPACK algorithms ($T, $m, $n)" for T in BLASFloats, m in (0, 54), n in (0, 37, m, 63)
         TestSuite.seed_rng!(123)
         LAPACK_SVD_ALGS = (QRIteration(), DivideAndConquer(), SafeDivideAndConquer(; fixgauge = true))
         TestSuite.test_svd(T, (m, n))
         TestSuite.test_svd_algs(T, (m, n), LAPACK_SVD_ALGS)
         @static if VERSION > v"1.11-" # Jacobi broken on 1.10
-            TestSuite.test_svd_algs(T, (m, n), (LAPACK_Jacobi(),); test_full = false, test_vals = false)
+            TestSuite.test_svd_algs(T, (m, n), (Jacobi(),); test_full = false, test_vals = false)
         end
+    end
+
+    # Sketched algorithms
+    for T in BLASFloats
+        m, n = 54, 63
+        rtol = sqrt(TestSuite.precision(T)) # extra square root
+        algs = [
+            SketchedAlgorithm(DefaultAlgorithm(), GaussianSketching(m ÷ 2, numiter = 4), truncrank(m ÷ 4)),
+        ]
+        TestSuite.test_sketched_svd(T, (m, n), algs; rtol)
+        TestSuite.test_sketched_svd(T, (n, m), algs)
     end
 
     # Generic floats:
@@ -47,7 +57,7 @@ end
 
 # CUDA tests
 # ------------
-if CUDA.functional()
+if false # CUDA.functional()
     # LAPACK algorithms:
     for T in BLASFloats, m in (0, 23), n in (0, 17, m, 27)
         TestSuite.seed_rng!(123)
@@ -62,7 +72,12 @@ if CUDA.functional()
         k = 5
         p = min(m, n) - k - 2
         p > 0 || continue
-        TestSuite.test_randomized_svd(CuMatrix{T}, (m, n), (MatrixAlgebraKit.TruncatedAlgorithm(CUSOLVER_Randomized(; k, p, niters = 20), truncrank(k)),))
+        cusolver_sketch = SketchedAlgorithm(
+            GaussianSketching(k; oversampling = p, niters = 20),
+            DefaultAlgorithm(),
+            MatrixAlgebraKit.CUSOLVER(),
+        )
+        TestSuite.test_randomized_svd(CuMatrix{T}, (m, n), (cusolver_sketch,))
     end
 
     # Diagonal:

--- a/test/decompositions/svd.jl
+++ b/test/decompositions/svd.jl
@@ -43,7 +43,7 @@ if !is_buildkite
     for T in GenericFloats, m in (0, 54), n in (0, 37, m, 63)
         TestSuite.seed_rng!(123)
         TestSuite.test_svd(T, (m, n))
-        TestSuite.test_svd_algs(T, (m, n), (GLA_QRIteration(),))
+        TestSuite.test_svd_algs(T, (m, n), (QRIteration(; driver = MatrixAlgebraKit.GLA()),))
     end
 
     # Diagonal:

--- a/test/decompositions/svd.jl
+++ b/test/decompositions/svd.jl
@@ -36,7 +36,7 @@ if !is_buildkite
             SketchedAlgorithm(; sketch = GaussianSketching(m ÷ 2, numiter = 4), trunc = truncrank(m ÷ 4)),
         ]
         TestSuite.test_sketched_svd(T, (m, n), algs; rtol)
-        TestSuite.test_sketched_svd(T, (n, m), algs)
+        TestSuite.test_sketched_svd(T, (n, m), algs; rtol)
     end
 
     # Generic floats:
@@ -57,7 +57,7 @@ end
 
 # CUDA tests
 # ------------
-if false # CUDA.functional()
+if CUDA.functional()
     # LAPACK algorithms:
     for T in BLASFloats, m in (0, 23), n in (0, 17, m, 27)
         TestSuite.seed_rng!(123)
@@ -66,18 +66,19 @@ if false # CUDA.functional()
         TestSuite.test_svd_algs(CuMatrix{T}, (m, n), CUDA_SVD_ALGS)
     end
 
-    # Randomized SVD:
+    # Sketched SVD:
     for T in BLASFloats, m in (0, 23), n in (0, 17, m, 27)
         TestSuite.seed_rng!(123)
         k = 5
         p = min(m, n) - k - 2
         p > 0 || continue
-        cusolver_sketch = SketchedAlgorithm(
-            GaussianSketching(k; oversampling = p, niters = 20),
-            DefaultAlgorithm(),
-            MatrixAlgebraKit.CUSOLVER(),
+        rtol = sqrt(TestSuite.precision(T)) # extra square root
+        cusolver_sketch = SketchedAlgorithm(;
+            sketch = GaussianSketching(k + p; numiter = 20),
+            trunc = truncrank(k),
+            driver = MatrixAlgebraKit.CUSOLVER(),
         )
-        TestSuite.test_randomized_svd(CuMatrix{T}, (m, n), (cusolver_sketch,))
+        TestSuite.test_sketched_svd(CuMatrix{T}, (m, n), (cusolver_sketch,); rtol)
     end
 
     # Diagonal:

--- a/test/decompositions/svd.jl
+++ b/test/decompositions/svd.jl
@@ -33,7 +33,7 @@ if !is_buildkite
         m, n = 54, 63
         rtol = sqrt(TestSuite.precision(T)) # extra square root
         algs = [
-            SketchedAlgorithm(DefaultAlgorithm(), GaussianSketching(m ÷ 2, numiter = 4), truncrank(m ÷ 4)),
+            SketchedAlgorithm(; sketch = GaussianSketching(m ÷ 2, numiter = 4), trunc = truncrank(m ÷ 4)),
         ]
         TestSuite.test_sketched_svd(T, (m, n), algs; rtol)
         TestSuite.test_sketched_svd(T, (n, m), algs)

--- a/test/sketching.jl
+++ b/test/sketching.jl
@@ -1,0 +1,17 @@
+using MatrixAlgebraKit
+
+BLASFloats = (Float32, Float64, ComplexF32, ComplexF64)
+
+@isdefined(TestSuite) || include("testsuite/TestSuite.jl")
+using .TestSuite
+
+is_buildkite = get(ENV, "BUILDKITE", "false") == "true"
+
+# CPU tests
+# ---------
+if !is_buildkite
+    @testset "Sketching ($T, $m, $n)" for T in BLASFloats, (m, n) in ((100, 40), (40, 100), (60, 60))
+        TestSuite.seed_rng!(123)
+        TestSuite.test_sketching(T, (m, n))
+    end
+end

--- a/test/testsuite/TestSuite.jl
+++ b/test/testsuite/TestSuite.jl
@@ -95,11 +95,17 @@ function instantiate_rank_deficient_matrix(T, sz; trunc = truncrank(div(min(sz..
     V, C = left_orth!(A; trunc)
     return mul!(A, V, C)
 end
-
 function instantiate_rank_deficient_matrix(::Type{T}, sz; trunc = truncrank(div(min(sz...), 2))) where {T <: Diagonal}
     A = instantiate_matrix(eltype(T), sz)
     V, C = left_orth!(A; trunc)
     return Diagonal(diag(mul!(A, V, C)))
+end
+
+function instantiate_almost_rank_deficient_matrix(T, sz; trunc = truncrank(div(min(sz...), 2)), atol::Real = 0, rtol::Real = precision(T))
+    A = instantiate_rank_deficient_matrix(T, sz; trunc)
+    noise = normalize(instantiate_matrix(T, sz))
+    A .+= max(atol, rtol * norm(A)) * noise
+    return A
 end
 
 include("ad_utils.jl")
@@ -116,6 +122,7 @@ include("decompositions/eig.jl")
 include("decompositions/eigh.jl")
 include("decompositions/orthnull.jl")
 include("decompositions/svd.jl")
+include("decompositions/sketching.jl")
 
 # Mooncake
 # --------

--- a/test/testsuite/TestSuite.jl
+++ b/test/testsuite/TestSuite.jl
@@ -101,7 +101,10 @@ function instantiate_rank_deficient_matrix(::Type{T}, sz; trunc = truncrank(div(
     return Diagonal(diag(mul!(A, V, C)))
 end
 
-function instantiate_almost_rank_deficient_matrix(T, sz; trunc = truncrank(div(min(sz...), 2)), atol::Real = 0, rtol::Real = precision(T))
+function instantiate_almost_rank_deficient_matrix(
+        T, sz;
+        trunc = truncrank(div(min(sz...), 2)), atol::Real = 0, rtol::Real = precision(T)
+    )
     A = instantiate_rank_deficient_matrix(T, sz; trunc)
     noise = normalize(instantiate_matrix(T, sz))
     A .+= max(atol, rtol * norm(A)) * noise

--- a/test/testsuite/decompositions/sketching.jl
+++ b/test/testsuite/decompositions/sketching.jl
@@ -1,0 +1,131 @@
+using TestExtras
+
+function test_sketching(T::Type, sz; kwargs...)
+    summary_str = testargs_summary(T, sz)
+    return @testset "sketching $summary_str" begin
+        test_left_sketch(T, sz; kwargs...)
+        test_right_sketch(T, sz; kwargs...)
+    end
+end
+
+function test_left_sketch(
+        T::Type, sz;
+        atol::Real = 0, rtol::Real = precision(T),
+        kwargs...
+    )
+    summary_str = testargs_summary(T, sz)
+    return @testset "left_sketch $summary_str" begin
+        m, n = sz
+        r = min(min(m, n) ÷ 4, 5)
+        r > 0 || return
+
+        A = instantiate_almost_rank_deficient_matrix(T, sz; trunc = truncrank(r), atol, rtol)
+        Ac = deepcopy(A)
+        k = min(r, m, n)
+
+        # Does the elementary functionality work
+        Q, B = @testinferred left_sketch(A; howmany = r)
+        @test size(Q) == (m, k)
+        @test eltype(Q) === float(eltype(T))
+        @test isisometric(Q; rtol, atol)
+        @test size(B) == (k, n)
+        @test eltype(B) === float(eltype(T))
+        @test B ≈ Q' * A atol = atol rtol = rtol
+        @test A ≈ Q * B atol = atol rtol = rtol
+        @test A == Ac
+
+        # Can I pass in outputs
+        Q, B = @testinferred left_sketch!(deepcopy(A), (Q, B); howmany = r)
+        @test size(Q) == (m, k)
+        @test eltype(Q) === float(eltype(T))
+        @test isisometric(Q; rtol, atol)
+        @test size(B) == (k, n)
+        @test eltype(B) === float(eltype(T))
+        @test B ≈ Q' * A atol = atol rtol = rtol
+        @test A ≈ Q * B atol = atol rtol = rtol
+
+        # Can I pass in keywords
+        rng = MersenneTwister(3)
+        Q, B = @testinferred left_sketch(A; howmany = r, rng)
+        rng = MersenneTwister(3)
+        Q′, B′ = @testinferred left_sketch(A; howmany = r, rng)
+        @test Q == Q′
+        @test B == B′
+
+        # Can I pass in algorithms
+        rng = MersenneTwister(3)
+        alg = GaussianSketching(r; rng)
+        Q′, B′ = @testinferred left_sketch(A, alg)
+        @test Q == Q′
+        @test B == B′
+
+        # Do power iterations improve accuracy
+        Aflat = instantiate_matrix(T, sz)
+        Q1, B1 = left_sketch(Aflat, GaussianSketching(r; numiter = 1, rng = MersenneTwister(123)))
+        Q5, B5 = left_sketch(Aflat, GaussianSketching(r; numiter = 5, rng = MersenneTwister(123)))
+        e1 = norm(Aflat - Q1 * B1) / norm(Aflat)
+        e5 = norm(Aflat - Q5 * B5) / norm(Aflat)
+        @test e5 ≤ e1 + rtol
+    end
+end
+
+function test_right_sketch(
+        T::Type, sz;
+        atol::Real = 0, rtol::Real = precision(T),
+        kwargs...
+    )
+    summary_str = testargs_summary(T, sz)
+    return @testset "right_sketch $summary_str" begin
+        m, n = sz
+        r = min(min(m, n) ÷ 4, 5)
+        r > 0 || return
+
+        A = instantiate_almost_rank_deficient_matrix(T, sz; trunc = truncrank(r), atol, rtol)
+        Ac = deepcopy(A)
+        k = min(r, m, n)
+
+        # Does the elementary functionality work
+        B, Pᴴ = @testinferred right_sketch(A; howmany = r)
+        @test size(B) == (m, k)
+        @test eltype(B) === float(eltype(T))
+        @test size(Pᴴ) == (k, n)
+        @test eltype(Pᴴ) === float(eltype(T))
+        @test isisometric(Pᴴ'; rtol, atol)
+        @test B ≈ A * Pᴴ' atol = atol rtol = rtol
+        @test A ≈ B * Pᴴ atol = atol rtol = rtol
+        @test A == Ac
+
+        # Can I pass in outputs
+        B, Pᴴ = @testinferred right_sketch!(deepcopy(A), (B, Pᴴ); howmany = r)
+        @test size(B) == (m, k)
+        @test eltype(B) === float(eltype(T))
+        @test size(Pᴴ) == (k, n)
+        @test eltype(Pᴴ) === float(eltype(T))
+        @test isisometric(Pᴴ'; rtol, atol)
+        @test B ≈ A * Pᴴ' atol = atol rtol = rtol
+        @test A ≈ B * Pᴴ atol = atol rtol = rtol
+
+        # Can I pass in keywords
+        rng = MersenneTwister(3)
+        B, Pᴴ = @testinferred right_sketch(A; howmany = r, rng)
+        rng = MersenneTwister(3)
+        B′, Pᴴ′ = @testinferred right_sketch(A; howmany = r, rng)
+        @test B == B′
+        @test Pᴴ == Pᴴ′
+
+        # Can I pass in algorithms
+        rng = MersenneTwister(3)
+        alg = GaussianSketching(r; rng)
+        B′, Pᴴ′ = @testinferred right_sketch(A, alg)
+        @test B == B′
+        @test Pᴴ == Pᴴ′
+
+        # Do power iterations improve accuracy
+        Aflat = instantiate_matrix(T, sz)
+        B1, P1 = right_sketch(Aflat, GaussianSketching(r; numiter = 1, rng = MersenneTwister(123)))
+        B5, P5 = right_sketch(Aflat, GaussianSketching(r; numiter = 5, rng = MersenneTwister(123)))
+        e1 = norm(Aflat - B1 * P1) / norm(Aflat)
+        e5 = norm(Aflat - B5 * P5) / norm(Aflat)
+        @test e5 ≤ e1 + rtol
+    end
+end

--- a/test/testsuite/decompositions/svd.jl
+++ b/test/testsuite/decompositions/svd.jl
@@ -371,19 +371,23 @@ function test_sketched_svd(
     return @testset "sketched svd_trunc! algorithm $alg $summary_str" for alg in algs
         @assert alg isa SketchedAlgorithm "Invalid sketched algorithm type: $(typeof(alg))"
 
-        A = instantiate_rank_deficient_matrix(T, sz; alg.trunc)
-        A += max(atol, rtol * norm(A)) * instantiate_matrix(T, sz)
+        A = instantiate_almost_rank_deficient_matrix(T, sz; alg.trunc, atol, rtol)
         Ac = deepcopy(A)
 
         alg2 = MatrixAlgebraKit.TruncatedAlgorithm(alg)
 
         U, S, Vᴴ, ϵ = @testinferred svd_trunc(A, alg)
         @test Ac == A
+        ϵ′ = norm(A - U * S * Vᴴ)
+        @test ϵ′ ≈ ϵ atol = sqrt(rtol) * max(one(ϵ′), ϵ′) # comparison to 0 is hard, very imprecise calculation
 
-        U′, S′, Vᴴ′, ϵ′ = svd_trunc(A, alg2)
+        U′, S′, Vᴴ′ = svd_trunc_no_error(A, alg2)
+
+        # Need gauge fixing for comparison
+        U, Vᴴ = MatrixAlgebraKit.gaugefix!(svd_trunc!, U, Vᴴ)
+        U′, Vᴴ′ = MatrixAlgebraKit.gaugefix!(svd_trunc!, U′, Vᴴ′)
         @test U ≈ U′ atol = atol rtol = rtol
         @test S ≈ S′ atol = atol rtol = rtol
         @test Vᴴ ≈ Vᴴ′ atol = atol rtol = rtol
-        @test ϵ ≈ ϵ′ atol = atol rtol = rtol
     end
 end

--- a/test/testsuite/decompositions/svd.jl
+++ b/test/testsuite/decompositions/svd.jl
@@ -363,15 +363,27 @@ function test_svd_trunc_algs(
     end
 end
 
-function test_randomized_svd(T::Type, sz, algs; kwargs...)
+function test_sketched_svd(
+        T::Type, sz, algs;
+        atol::Real = 0, rtol::Real = precision(eltype(T)), kwargs...
+    )
     summary_str = testargs_summary(T, sz)
-    return @testset "randomized svd_trunc! algorithm $alg $summary_str" for alg in algs
-        A = instantiate_matrix(T, sz)
+    return @testset "sketched svd_trunc! algorithm $alg $summary_str" for alg in algs
+        @assert alg isa SketchedAlgorithm "Invalid sketched algorithm type: $(typeof(alg))"
+
+        A = instantiate_rank_deficient_matrix(T, sz; alg.trunc)
+        A += max(atol, rtol * norm(A)) * instantiate_matrix(T, sz)
         Ac = deepcopy(A)
-        m, n = size(A)
-        minmn = min(m, n)
-        S₀ = collect(svd_vals(A))
-        U1, S1, V1ᴴ, ϵ1 = @testinferred svd_trunc(A; alg)
-        @test collect(diagview(S1))[1:alg.alg.k] ≈ S₀[1:alg.alg.k]
+
+        alg2 = MatrixAlgebraKit.TruncatedAlgorithm(alg)
+
+        U, S, Vᴴ, ϵ = @testinferred svd_trunc(A, alg)
+        @test Ac == A
+
+        U′, S′, Vᴴ′, ϵ′ = svd_trunc(A, alg2)
+        @test U ≈ U′ atol = atol rtol = rtol
+        @test S ≈ S′ atol = atol rtol = rtol
+        @test Vᴴ ≈ Vᴴ′ atol = atol rtol = rtol
+        @test ϵ ≈ ϵ′ atol = atol rtol = rtol
     end
 end


### PR DESCRIPTION
This PR implements infrastructure for working with matrix sketches, in particular through Gaussian sampling.
The main additions are `left_sketch!` and `right_sketch!`, which could be thought of as `left_orth` with a sketching truncation strategy (although not implemented that way).

Additionally, this brings the `CUSOLVER_Randomized` algorithm implementation on equal footing by using a `Driver` to select between the `CUSOLVER` implementation and the `Native` one.


### Sketching API

- `left_sketch[!](A; howmany, kwargs...) -> (Q, B)` with `Q` an `m×k` isometry and `B = Q'·A`.
- `right_sketch[!](A; howmany, kwargs...) -> (B, Pᴴ)` with `Pᴴ` a `k×n` co-isometry and `B = A·Pᴴ'`.
- `abstract type SketchingStrategy <: AbstractAlgorithm` — supertype for sketching primitives.
- `GaussianSketching(howmany; numiter=2, rng=default_rng())` — the one concrete strategy currently shipped.

### Sketched SVD

- `SketchedAlgorithm{A,S,T,D}` — `@kwdef` wrapper bundling `alg` (small dense factorization), `sketch` (`SketchingStrategy`), `trunc` (`TruncationStrategy`), and `driver` (`Driver`), to denote decomposing via sketch + decompose + truncate. Mimics `TruncatedAlgorithm`.
- `svd_trunc[!]` and `svd_trunc_no_error[!]` now dispatch on `SketchedAlgorithm`.
  They allocate `(U, S, Vᴴ)` sized for the sketch (`k = sketch.howmany`), check shapes, then call `gesvdr!(driver, A, S, U, Vᴴ; sketch, alg, trunc)`.
- Truncation error: `ε = sqrt((‖A‖+‖S‖)(‖A‖−‖S‖))`, identical to the old `CUSOLVER_Randomized` path.
- The CUDA extension now implements `gesvdr!(::CUSOLVER, A, S, U, Vᴴ; sketch, trunc, alg=nothing)` directly. It currently only accepts `sketch::GaussianSketching` and `trunc::TruncationByOrder` (i.e. `truncrank`) and ignores the inner `alg`. Requires dedicated overloads for the allocation of the output because of CUSOLVER conventions.
- `CUSOLVER_Randomized(; k, p, niters)` reimplemented as `SketchedAlgorithm(; sketch=GaussianSketching(k+p; numiter=niters+1), truncrank(k); driver=CUSOLVER())`. Non-breaking deprecation

## Design choices/questions

### 1. `left_sketch!` vs `left_orth!`

I had a hard time deciding between overloading `left_orth!` directly or introducing a dedicated `left_sketch` function. For simplicity I kept it separate for now, mostly since this is easier to reason through while fleshing out the design, but there might be a reasonable point to be made to merge the two.

### 2. Sketching as an algorithm vs Sketching as a truncation strategy

In the `svd_trunc` implementation, I chose to have **both** `trunc` and `sketch` as a keyword argument, rather than trying to fit this through the same keyword. Again, this is mostly for convenience while I was playing around with this, but we could conceive of a way to merge the two concepts, especially if we decide `left_orth!(A; trunc=gaussiansketch(...))` is a reasonable approach.

### 3. Allocating outputs

One of the things I struggled the most with is the issue of deciding what `initialize_output(svd_trunc!, A, ::SketchedAlgorithm)` should return.
The main issue is that we already are abusing this a bit for the `::TruncatedAlgorithm` codepath, where by convention the `USVh` we pass in is the one that will be used for the `svd_compact!` inside, and is not equivalent to the one that is outputted.
For `::SketchedAlgorithm`, I therefore chose to pass in the sketched sizes, since that is some workspace that can be reused, and that has similar semantics, but it is definitely true that this is a bit unintuitive.

However, the biggest struggle in changing this is that our automatic differentiation implementations hinge on the fact that everything passes through `svd_trunc!(A, out, alg)` in the end, so simply not supporting passing in an `out` argument has quite some implications for the remainder of the code.

This is probably a design choice that we could consider revisiting for a v0.7 version of MatrixAlgebraKit, since it might just be that for these cases where the output size is hard to determine beforehand, it doesn't necessarily make too much sense to allow passing it in as inputs.
The alternative would be to start playing around with "reallocation" strategies, where we shrink/expand provided inputs if they don't have the correct sizes. This does however feel like it might just be a bit too convoluted for what it buys us.

### 4. Truncation error formula

```julia
ε = sqrt((‖A‖ + ‖S‖) * (‖A‖ − ‖S‖))
```

This is the `‖A‖_F^2 − ‖S‖_F^2` identity, written for numerical stability.
However, I had to significantly lower the tolerances for any such tests, since the numerical accuracy of the sketching and the floating point errors are quite finicky for this.
This is of course the same discussion we had before, where it is not clear to me that `svd_trunc` really should have the responsibility to provide truncation errors, and `svd_trunc_no_error` is a way more sensible default mode.
Presumably this is fine as long as it is clearly documented?

### 5. Gauge fixing depends on the exact truncation path

In the current implementation, the gauge-fixing happens at the moment of decomposing the inner small core tensor, which will then still get unprojected onto a larger space through the sketch.
While it is somewhat straightforward to change this, it might be confusing that there are gaugefix keywords at multiple places, which don't have the same effect.
I'm not sure what the best way forwards is for this, but this might require some more discussion.


## TODO

- [ ] Documentation page
- [ ] Resolve discussions above
- [ ] Testing in the context of AD
- [ ] Testing in the context of GPU