### PR TITLE
Make `svd_pullback!` GPU-compatible

### DIFF
--- a/ext/MatrixAlgebraKitAMDGPUExt/MatrixAlgebraKitAMDGPUExt.jl
+++ b/ext/MatrixAlgebraKitAMDGPUExt/MatrixAlgebraKitAMDGPUExt.jl
@@ -191,7 +191,7 @@ function svd_rank(S::AnyROCVector; rank_atol = MatrixAlgebraKit.default_pullback
 end
 
 function svd_pullback!(ΔA::AnyROCMatrix, A, USVᴴ, ΔUSVᴴ, ind::AnyROCVector; kwargs...)
-    svd_pullback!(ΔA, A, USVᴴ, ΔUSVᴴ, collect(ind); kwargs...)
+    return svd_pullback!(ΔA, A, USVᴴ, ΔUSVᴴ, collect(ind); kwargs...)
 end
 
 end

--- a/ext/MatrixAlgebraKitAMDGPUExt/MatrixAlgebraKitAMDGPUExt.jl
+++ b/ext/MatrixAlgebraKitAMDGPUExt/MatrixAlgebraKitAMDGPUExt.jl
@@ -186,8 +186,7 @@ function _sylvester(A::AnyROCMatrix, B::AnyROCMatrix, C::AnyROCMatrix)
 end
 
 function svd_rank(S::AnyROCVector; rank_atol = MatrixAlgebraKit.default_pullback_rank_atol(S))
-    r = findlast(s -> s ≥ rank_atol, S)
-    return isnothing(r) ? length(S) : r
+    return something(findlast(≥(rank_atol), S), 0)
 end
 
 function svd_pullback!(ΔA::AnyROCMatrix, A, USVᴴ, ΔUSVᴴ, ind::AnyROCVector; kwargs...)

--- a/ext/MatrixAlgebraKitAMDGPUExt/MatrixAlgebraKitAMDGPUExt.jl
+++ b/ext/MatrixAlgebraKitAMDGPUExt/MatrixAlgebraKitAMDGPUExt.jl
@@ -8,7 +8,7 @@ using MatrixAlgebraKit: ROCSOLVER, LQViaTransposedQR, TruncationStrategy, NoTrun
 using MatrixAlgebraKit: default_qr_algorithm, default_lq_algorithm, default_svd_algorithm, default_eigh_algorithm
 import MatrixAlgebraKit: geqrf!, ungqr!, unmqr!, gesvd!, gesvdj!
 import MatrixAlgebraKit: heevj!, heevd!, heev!, heevx!
-import MatrixAlgebraKit: _sylvester, svd_rank
+import MatrixAlgebraKit: _sylvester, svd_rank, svd_pullback!
 using AMDGPU
 using LinearAlgebra
 using LinearAlgebra: BlasFloat
@@ -185,6 +185,13 @@ function _sylvester(A::AnyROCMatrix, B::AnyROCMatrix, C::AnyROCMatrix)
     return ROCArray(hX)
 end
 
-svd_rank(S::AnyROCVector; rank_atol = MatrixAlgebraKit.default_pullback_rank_atol(S)) = findlast(s -> s ≥ rank_atol, S)
+function svd_rank(S::AnyROCVector; rank_atol = MatrixAlgebraKit.default_pullback_rank_atol(S))
+    r = findlast(s -> s ≥ rank_atol, S)
+    return isnothing(r) ? length(S) : r
+end
+
+function svd_pullback!(ΔA::AnyROCMatrix, A, USVᴴ, ΔUSVᴴ, ind::AnyROCVector; kwargs...)
+    svd_pullback!(ΔA, A, USVᴴ, ΔUSVᴴ, collect(ind); kwargs...)
+end
 
 end

--- a/ext/MatrixAlgebraKitAMDGPUExt/MatrixAlgebraKitAMDGPUExt.jl
+++ b/ext/MatrixAlgebraKitAMDGPUExt/MatrixAlgebraKitAMDGPUExt.jl
@@ -185,6 +185,6 @@ function _sylvester(A::AnyROCMatrix, B::AnyROCMatrix, C::AnyROCMatrix)
     return ROCArray(hX)
 end
 
-svd_rank(S::AnyROCVector, rank_atol) = findlast(s -> s ≥ rank_atol, S)
+svd_rank(S::AnyROCVector; rank_atol = MatrixAlgebraKit.default_pullback_rank_atol(S)) = findlast(s -> s ≥ rank_atol, S)
 
 end

--- a/ext/MatrixAlgebraKitCUDAExt/MatrixAlgebraKitCUDAExt.jl
+++ b/ext/MatrixAlgebraKitCUDAExt/MatrixAlgebraKitCUDAExt.jl
@@ -8,7 +8,7 @@ using MatrixAlgebraKit: CUSOLVER, LQViaTransposedQR, TruncationByValue, Abstract
 using MatrixAlgebraKit: default_qr_algorithm, default_lq_algorithm, default_svd_algorithm, default_eig_algorithm, default_eigh_algorithm
 import MatrixAlgebraKit: geqrf!, ungqr!, unmqr!, gesvd!, gesvdp!, gesvdr!, gesvdj!
 import MatrixAlgebraKit: heevj!, heevd!, geev!
-import MatrixAlgebraKit: _gpu_Xgesvdr!, _sylvester, svd_rank
+import MatrixAlgebraKit: _gpu_Xgesvdr!, _sylvester, svd_rank, svd_pullback!
 using CUDA, CUDA.cuBLAS
 using CUDA: i32
 using LinearAlgebra
@@ -197,6 +197,13 @@ function _sylvester(A::AnyCuMatrix, B::AnyCuMatrix, C::AnyCuMatrix)
     return CuArray(hX)
 end
 
-svd_rank(S::AnyCuVector; rank_atol = MatrixAlgebraKit.default_pullback_rank_atol(S)) = findlast(s -> s ≥ rank_atol, S)
+function svd_rank(S::AnyCuVector; rank_atol = MatrixAlgebraKit.default_pullback_rank_atol(S))
+    r = findlast(s -> s ≥ rank_atol, S)
+    return isnothing(r) ? length(S) : r
+end
+
+function svd_pullback!(ΔA::AnyCuMatrix, A, USVᴴ, ΔUSVᴴ, ind::AnyCuVector; kwargs...)
+    svd_pullback!(ΔA, A, USVᴴ, ΔUSVᴴ, collect(ind); kwargs...)
+end
 
 end

--- a/ext/MatrixAlgebraKitCUDAExt/MatrixAlgebraKitCUDAExt.jl
+++ b/ext/MatrixAlgebraKitCUDAExt/MatrixAlgebraKitCUDAExt.jl
@@ -203,7 +203,7 @@ function svd_rank(S::AnyCuVector; rank_atol = MatrixAlgebraKit.default_pullback_
 end
 
 function svd_pullback!(ΔA::AnyCuMatrix, A, USVᴴ, ΔUSVᴴ, ind::AnyCuVector; kwargs...)
-    svd_pullback!(ΔA, A, USVᴴ, ΔUSVᴴ, collect(ind); kwargs...)
+    return svd_pullback!(ΔA, A, USVᴴ, ΔUSVᴴ, collect(ind); kwargs...)
 end
 
 end

--- a/ext/MatrixAlgebraKitCUDAExt/MatrixAlgebraKitCUDAExt.jl
+++ b/ext/MatrixAlgebraKitCUDAExt/MatrixAlgebraKitCUDAExt.jl
@@ -198,8 +198,7 @@ function _sylvester(A::AnyCuMatrix, B::AnyCuMatrix, C::AnyCuMatrix)
 end
 
 function svd_rank(S::AnyCuVector; rank_atol = MatrixAlgebraKit.default_pullback_rank_atol(S))
-    r = findlast(s -> s ≥ rank_atol, S)
-    return isnothing(r) ? length(S) : r
+    return something(findlast(≥(rank_atol), S), 0)
 end
 
 function svd_pullback!(ΔA::AnyCuMatrix, A, USVᴴ, ΔUSVᴴ, ind::AnyCuVector; kwargs...)

--- a/ext/MatrixAlgebraKitCUDAExt/MatrixAlgebraKitCUDAExt.jl
+++ b/ext/MatrixAlgebraKitCUDAExt/MatrixAlgebraKitCUDAExt.jl
@@ -197,6 +197,6 @@ function _sylvester(A::AnyCuMatrix, B::AnyCuMatrix, C::AnyCuMatrix)
     return CuArray(hX)
 end
 
-svd_rank(S::AnyCuVector, rank_atol) = findlast(s -> s ≥ rank_atol, S)
+svd_rank(S::AnyCuVector; rank_atol = MatrixAlgebraKit.default_pullback_rank_atol(S)) = findlast(s -> s ≥ rank_atol, S)
 
 end

--- a/ext/MatrixAlgebraKitEnzymeExt/MatrixAlgebraKitEnzymeExt.jl
+++ b/ext/MatrixAlgebraKitEnzymeExt/MatrixAlgebraKitEnzymeExt.jl
@@ -274,7 +274,7 @@ function EnzymeRules.reverse(
     Aval = nothing
     USVᴴval = something(cache_USVᴴ, USVᴴ.val)
     if !isa(A, Const)
-        svd_pullback!(A.dval, Aval, USVᴴval, dUSVᴴ, ind)
+        svd_pullback!(A.dval, Aval, USVᴴval, dUSVᴴ, collect(ind))
     end
     !isa(USVᴴ, Const) && make_zero!(USVᴴ.dval)
     return (nothing, nothing, nothing)

--- a/ext/MatrixAlgebraKitEnzymeExt/MatrixAlgebraKitEnzymeExt.jl
+++ b/ext/MatrixAlgebraKitEnzymeExt/MatrixAlgebraKitEnzymeExt.jl
@@ -274,7 +274,7 @@ function EnzymeRules.reverse(
     Aval = nothing
     USVᴴval = something(cache_USVᴴ, USVᴴ.val)
     if !isa(A, Const)
-        svd_pullback!(A.dval, Aval, USVᴴval, dUSVᴴ, collect(ind))
+        svd_pullback!(A.dval, Aval, USVᴴval, dUSVᴴ, ind)
     end
     !isa(USVᴴ, Const) && make_zero!(USVᴴ.dval)
     return (nothing, nothing, nothing)

--- a/ext/MatrixAlgebraKitMooncakeExt/MatrixAlgebraKitMooncakeExt.jl
+++ b/ext/MatrixAlgebraKitMooncakeExt/MatrixAlgebraKitMooncakeExt.jl
@@ -15,6 +15,20 @@ using LinearAlgebra
 
 Mooncake.tangent_type(::Type{<:MatrixAlgebraKit.AbstractAlgorithm}) = Mooncake.NoTangent
 
+# needed for GPU tests because Mooncake can't differentiate through CUDA kernels
+@is_primitive Mooncake.DefaultCtx Mooncake.ReverseMode Tuple{typeof(zero!), AbstractArray}
+function Mooncake.rrule!!(::CoDual{typeof(zero!)}, A_dA::CoDual)
+    A, dA = arrayify(A_dA)
+    Ac = copy(A)
+    zero!(A)
+    function zero_adjoint(::NoRData)
+        copy!(A, Ac)
+        zero!(dA)
+        return NoRData(), NoRData()
+    end
+    return A_dA, zero_adjoint
+end
+
 # two-argument in-place factorizations like LQ, QR, EIG
 for (f!, f, pb, adj) in (
         (:qr_full!, :qr_full, :qr_pullback!, :qr_adjoint),
@@ -614,7 +628,7 @@ function Mooncake.rrule!!(::CoDual{typeof(svd_trunc!)}, A_dA::CoDual, USVᴴ_dUS
         _warn_pullback_truncerror(dϵ)
 
         # compute pullbacks
-        svd_pullback!(dA, Ac, USVᴴ, dUSVᴴtrunc, ind)
+        svd_pullback!(dA, Ac, USVᴴ, dUSVᴴtrunc, collect(ind))
         zero!.(dUSVᴴtrunc) # since this is allocated in this function this is probably not required
         zero!.(dUSVᴴ)
 
@@ -671,7 +685,7 @@ function Mooncake.rrule!!(::CoDual{typeof(svd_trunc)}, A_dA::CoDual, alg_dalg::C
     dUSVᴴtrunc = last.(arrayify.(USVᴴtrunc, Base.front(Mooncake.tangent(USVᴴtrunc_dUSVᴴtrunc))))
     function svd_trunc_adjoint((_, _, _, dϵ)::Tuple{NoRData, NoRData, NoRData, Real})
         _warn_pullback_truncerror(dϵ)
-        svd_pullback!(dA, A, USVᴴ, dUSVᴴtrunc, ind)
+        svd_pullback!(dA, A, USVᴴ, dUSVᴴtrunc, collect(ind))
         zero!.(dUSVᴴtrunc) # since this is allocated in this function this is probably not required
         return ntuple(Returns(NoRData()), 3)
     end
@@ -741,7 +755,7 @@ function Mooncake.rrule!!(::CoDual{typeof(svd_trunc_no_error!)}, A_dA::CoDual, U
     dUSVᴴtrunc = last.(arrayify.(USVᴴtrunc, Mooncake.tangent(USVᴴtrunc_dUSVᴴtrunc)))
     function svd_trunc_adjoint(::NoRData)
         # compute pullbacks
-        svd_pullback!(dA, Ac, USVᴴ, dUSVᴴtrunc, ind)
+        svd_pullback!(dA, Ac, USVᴴ, dUSVᴴtrunc, collect(ind))
         zero!.(dUSVᴴ)
 
         # restore state
@@ -794,7 +808,7 @@ function Mooncake.rrule!!(::CoDual{typeof(svd_trunc_no_error)}, A_dA::CoDual, al
     # define pullback
     dUSVᴴtrunc = last.(arrayify.(USVᴴtrunc, Mooncake.tangent(USVᴴtrunc_dUSVᴴtrunc)))
     function svd_trunc_adjoint(::NoRData)
-        svd_pullback!(dA, A, USVᴴ, dUSVᴴtrunc, ind)
+        svd_pullback!(dA, A, USVᴴ, dUSVᴴtrunc, collect(ind))
         zero!.(dUSVᴴtrunc) # since this is allocated in this function this is probably not required
         return ntuple(Returns(NoRData()), 3)
     end

--- a/ext/MatrixAlgebraKitMooncakeExt/MatrixAlgebraKitMooncakeExt.jl
+++ b/ext/MatrixAlgebraKitMooncakeExt/MatrixAlgebraKitMooncakeExt.jl
@@ -628,7 +628,7 @@ function Mooncake.rrule!!(::CoDual{typeof(svd_trunc!)}, A_dA::CoDual, USVᴴ_dUS
         _warn_pullback_truncerror(dϵ)
 
         # compute pullbacks
-        svd_pullback!(dA, Ac, USVᴴ, dUSVᴴtrunc, collect(ind))
+        svd_pullback!(dA, Ac, USVᴴ, dUSVᴴtrunc, ind)
         zero!.(dUSVᴴtrunc) # since this is allocated in this function this is probably not required
         zero!.(dUSVᴴ)
 
@@ -685,7 +685,7 @@ function Mooncake.rrule!!(::CoDual{typeof(svd_trunc)}, A_dA::CoDual, alg_dalg::C
     dUSVᴴtrunc = last.(arrayify.(USVᴴtrunc, Base.front(Mooncake.tangent(USVᴴtrunc_dUSVᴴtrunc))))
     function svd_trunc_adjoint((_, _, _, dϵ)::Tuple{NoRData, NoRData, NoRData, Real})
         _warn_pullback_truncerror(dϵ)
-        svd_pullback!(dA, A, USVᴴ, dUSVᴴtrunc, collect(ind))
+        svd_pullback!(dA, A, USVᴴ, dUSVᴴtrunc, ind)
         zero!.(dUSVᴴtrunc) # since this is allocated in this function this is probably not required
         return ntuple(Returns(NoRData()), 3)
     end
@@ -755,7 +755,7 @@ function Mooncake.rrule!!(::CoDual{typeof(svd_trunc_no_error!)}, A_dA::CoDual, U
     dUSVᴴtrunc = last.(arrayify.(USVᴴtrunc, Mooncake.tangent(USVᴴtrunc_dUSVᴴtrunc)))
     function svd_trunc_adjoint(::NoRData)
         # compute pullbacks
-        svd_pullback!(dA, Ac, USVᴴ, dUSVᴴtrunc, collect(ind))
+        svd_pullback!(dA, Ac, USVᴴ, dUSVᴴtrunc, ind)
         zero!.(dUSVᴴ)
 
         # restore state
@@ -808,7 +808,7 @@ function Mooncake.rrule!!(::CoDual{typeof(svd_trunc_no_error)}, A_dA::CoDual, al
     # define pullback
     dUSVᴴtrunc = last.(arrayify.(USVᴴtrunc, Mooncake.tangent(USVᴴtrunc_dUSVᴴtrunc)))
     function svd_trunc_adjoint(::NoRData)
-        svd_pullback!(dA, A, USVᴴ, dUSVᴴtrunc, collect(ind))
+        svd_pullback!(dA, A, USVᴴ, dUSVᴴtrunc, ind)
         zero!.(dUSVᴴtrunc) # since this is allocated in this function this is probably not required
         return ntuple(Returns(NoRData()), 3)
     end

--- a/src/pullbacks/svd.jl
+++ b/src/pullbacks/svd.jl
@@ -96,7 +96,7 @@ function check_and_prepare_svd_cotangents(
         ΔS₁[1:length(good_indS)] .= real.(ΔS[good_indS])
         length(ΔS₁) == length(S₁) || throw(DimensionMismatch(lazy"length of ΔS₁ ($(length(ΔS₁))) does not match length of S₁ ($(length(S₁)))"))
         badΔS₁ = view(ΔS, bad_indS)
-        Δgauge = max(Δgauge, maximum(abs, badΔS₁; init = abs(zero(eltype(ΔS))))
+        Δgauge = max(Δgauge, maximum(abs, badΔS₁; init = abs(zero(eltype(ΔS)))))
     else
         ΔS₁ = nothing
     end

--- a/src/pullbacks/svd.jl
+++ b/src/pullbacks/svd.jl
@@ -96,7 +96,7 @@ function check_and_prepare_svd_cotangents(
         ΔS₁[1:length(good_indS)] .= real.(ΔS[good_indS])
         length(ΔS₁) == length(S₁) || throw(DimensionMismatch(lazy"length of ΔS₁ ($(length(ΔS₁))) does not match length of S₁ ($(length(S₁)))"))
         badΔS₁ = view(ΔS, bad_indS)
-        Δgauge = max(Δgauge, maximum(abs, badΔS₁; init = 0.0))
+        Δgauge = max(Δgauge, maximum(abs, badΔS₁; init = abs(zero(eltype(ΔS))))
     else
         ΔS₁ = nothing
     end

--- a/src/pullbacks/svd.jl
+++ b/src/pullbacks/svd.jl
@@ -94,7 +94,6 @@ function check_and_prepare_svd_cotangents(
         good_indS = _ind_intersect(1:r, indS)
         ΔS₁ = zero(S₁)
         ΔS₁[1:length(good_indS)] .= real.(ΔS[good_indS])
-        length(ΔS₁) == length(S₁) || throw(DimensionMismatch(lazy"length of ΔS₁ ($(length(ΔS₁))) does not match length of S₁ ($(length(S₁)))"))
         badΔS₁ = view(ΔS, bad_indS)
         Δgauge = max(Δgauge, maximum(abs, badΔS₁; init = abs(zero(eltype(ΔS)))))
     else

--- a/src/pullbacks/svd.jl
+++ b/src/pullbacks/svd.jl
@@ -91,10 +91,12 @@ function check_and_prepare_svd_cotangents(
         ΔS = diagview(ΔSmat)
         length(indS) == length(ΔS) || throw(DimensionMismatch(lazy"length of selected S values ($(length(indS))) does not match length of ΔS ($(length(ΔS)))"))
         bad_indS = _ind_intersect(r+1:length(ΔS), indS)
-        ΔS₁ = real(ΔS)
-        badΔS₁ = view(ΔS₁, bad_indS)
+        good_indS = _ind_intersect(1:r, indS)
+        ΔS₁ = zero(S₁)
+        view(ΔS₁, 1:length(good_indS)) .= real.(view(ΔS, good_indS))
+        length(ΔS₁) == length(S₁) || throw(DimensionMismatch(lazy"length of ΔS₁ ($(length(ΔS₁))) does not match length of S₁ ($(length(S₁)))"))
+        badΔS₁ = view(ΔS, bad_indS)
         Δgauge = max(Δgauge, maximum(abs, badΔS₁))
-        badΔS₁ .= 0
     else
         ΔS₁ = nothing
     end

--- a/src/pullbacks/svd.jl
+++ b/src/pullbacks/svd.jl
@@ -96,7 +96,7 @@ function check_and_prepare_svd_cotangents(
         view(ΔS₁, 1:length(good_indS)) .= real.(view(ΔS, good_indS))
         length(ΔS₁) == length(S₁) || throw(DimensionMismatch(lazy"length of ΔS₁ ($(length(ΔS₁))) does not match length of S₁ ($(length(S₁)))"))
         badΔS₁ = view(ΔS, bad_indS)
-        Δgauge = max(Δgauge, maximum(abs, badΔS₁))
+        Δgauge = max(Δgauge, maximum(abs, badΔS₁); init = 0.0)
     else
         ΔS₁ = nothing
     end

--- a/src/pullbacks/svd.jl
+++ b/src/pullbacks/svd.jl
@@ -93,7 +93,7 @@ function check_and_prepare_svd_cotangents(
         bad_indS = _ind_intersect((r + 1):length(ΔS), indS)
         good_indS = _ind_intersect(1:r, indS)
         ΔS₁ = zero(S₁)
-        view(ΔS₁, 1:length(good_indS)) .= real.(view(ΔS, good_indS))
+        ΔS₁[1:length(good_indS)] .= real.(ΔS[good_indS])
         length(ΔS₁) == length(S₁) || throw(DimensionMismatch(lazy"length of ΔS₁ ($(length(ΔS₁))) does not match length of S₁ ($(length(S₁)))"))
         badΔS₁ = view(ΔS, bad_indS)
         Δgauge = max(Δgauge, maximum(abs, badΔS₁; init = 0.0))

--- a/src/pullbacks/svd.jl
+++ b/src/pullbacks/svd.jl
@@ -90,11 +90,11 @@ function check_and_prepare_svd_cotangents(
     if !iszerotangent(ΔSmat)
         ΔS = diagview(ΔSmat)
         length(indS) == length(ΔS) || throw(DimensionMismatch(lazy"length of selected S values ($(length(indS))) does not match length of ΔS ($(length(ΔS)))"))
-        ΔS₁ = zero(S₁)
-        good_indS = findall(i -> i <= r, indS)
-        bad_indS = setdiff(1:length(indS), good_indS)
-        ΔS₁[indS[good_indS]] = real.(ΔS[good_indS])
-        Δgauge = max(Δgauge, mapreduce(abs, max, ΔS[bad_indS]))
+        bad_indS = _ind_intersect(r+1:length(ΔS), indS)
+        ΔS₁ = real(ΔS)
+        badΔS₁ = view(ΔS₁, bad_indS)
+        Δgauge = max(Δgauge, maximum(abs, badΔS₁))
+        badΔS₁ .= 0
     else
         ΔS₁ = nothing
     end

--- a/src/pullbacks/svd.jl
+++ b/src/pullbacks/svd.jl
@@ -90,7 +90,7 @@ function check_and_prepare_svd_cotangents(
     if !iszerotangent(ΔSmat)
         ΔS = diagview(ΔSmat)
         length(indS) == length(ΔS) || throw(DimensionMismatch(lazy"length of selected S values ($(length(indS))) does not match length of ΔS ($(length(ΔS)))"))
-        bad_indS = _ind_intersect(r+1:length(ΔS), indS)
+        bad_indS = _ind_intersect((r + 1):length(ΔS), indS)
         good_indS = _ind_intersect(1:r, indS)
         ΔS₁ = zero(S₁)
         view(ΔS₁, 1:length(good_indS)) .= real.(view(ΔS, good_indS))

--- a/src/pullbacks/svd.jl
+++ b/src/pullbacks/svd.jl
@@ -96,7 +96,7 @@ function check_and_prepare_svd_cotangents(
         view(ΔS₁, 1:length(good_indS)) .= real.(view(ΔS, good_indS))
         length(ΔS₁) == length(S₁) || throw(DimensionMismatch(lazy"length of ΔS₁ ($(length(ΔS₁))) does not match length of S₁ ($(length(S₁)))"))
         badΔS₁ = view(ΔS, bad_indS)
-        Δgauge = max(Δgauge, maximum(abs, badΔS₁); init = 0.0)
+        Δgauge = max(Δgauge, maximum(abs, badΔS₁; init = 0.0))
     else
         ΔS₁ = nothing
     end

--- a/src/pullbacks/svd.jl
+++ b/src/pullbacks/svd.jl
@@ -85,19 +85,16 @@ function check_and_prepare_svd_cotangents(
     bc = Base.broadcasted(S₁', S₁, aUᴴΔU₁, aVᴴΔV₁) do s₁, s₂, u, v
         return abs(s₁ - s₂) < degeneracy_atol ? u + v : zero(u) + zero(v)
     end
-    Δgauge = max(Δgauge, norm(bc, Inf))
+    Δgauge = max(Δgauge, maximum(abs, bc))
 
     if !iszerotangent(ΔSmat)
         ΔS = diagview(ΔSmat)
         length(indS) == length(ΔS) || throw(DimensionMismatch(lazy"length of selected S values ($(length(indS))) does not match length of ΔS ($(length(ΔS)))"))
         ΔS₁ = zero(S₁)
-        for (j, i) in enumerate(indS)
-            if i <= r
-                ΔS₁[i] = real(ΔS[j])
-            else
-                Δgauge = max(Δgauge, abs(ΔS[j]))
-            end
-        end
+        good_indS = findall(i -> i <= r, indS)
+        bad_indS = setdiff(1:length(indS), good_indS)
+        ΔS₁[indS[good_indS]] = real.(ΔS[good_indS])
+        Δgauge = max(Δgauge, mapreduce(abs, max, ΔS[bad_indS]))
     else
         ΔS₁ = nothing
     end

--- a/test/mooncake/svd.jl
+++ b/test/mooncake/svd.jl
@@ -20,4 +20,11 @@ for T in (BLASFloats..., GenericFloats...), n in (17, m, 23)
             TestSuite.test_mooncake_svd(AT, m; atol = m * n * TestSuite.precision(T), rtol = m * n * TestSuite.precision(T))
         end
     end
+    if T ∈ BLASFloats
+        TestSuite.test_mooncake_svd(CuMatrix{T}, (m, n); atol = m * n * TestSuite.precision(T), rtol = m * n * TestSuite.precision(T))
+        if m == n
+            AT = Diagonal{T, CuVector{T}}
+            TestSuite.test_mooncake_svd(AT, m; atol = m * n * TestSuite.precision(T), rtol = m * n * TestSuite.precision(T))
+        end
+    end
 end

--- a/test/mooncake/svd.jl
+++ b/test/mooncake/svd.jl
@@ -20,7 +20,7 @@ for T in (BLASFloats..., GenericFloats...), n in (17, m, 23)
             TestSuite.test_mooncake_svd(AT, m; atol = m * n * TestSuite.precision(T), rtol = m * n * TestSuite.precision(T))
         end
     end
-    if T ∈ BLASFloats
+    if T ∈ BLASFloats && CUDA.functional()
         TestSuite.test_mooncake_svd(CuMatrix{T}, (m, n); atol = m * n * TestSuite.precision(T), rtol = m * n * TestSuite.precision(T))
         if m == n
             AT = Diagonal{T, CuVector{T}}

--- a/test/testsuite/enzyme/svd.jl
+++ b/test/testsuite/enzyme/svd.jl
@@ -69,7 +69,7 @@ function test_enzyme_svd_trunc(
         end
         @testset "trunctol" begin
             S = svd_vals(A, alg)
-            trunc = trunctol(atol = S[1] / 2)
+            trunc = trunctol(atol = maximum(S) / 2)
             truncalg = TruncatedAlgorithm(alg, trunc)
             USVᴴ, _, ΔUSVᴴ, ΔUSVᴴtrunc = ad_svd_trunc_setup(A, truncalg)
             test_reverse(svd_trunc_no_error, RT, (A, TA), (truncalg, Const); atol, rtol, output_tangent = ΔUSVᴴtrunc, fdm)

--- a/test/testsuite/mooncake/svd.jl
+++ b/test/testsuite/mooncake/svd.jl
@@ -141,7 +141,7 @@ function test_mooncake_svd_trunc(
 
         @testset "trunctol" begin
             S = svd_vals(A)
-            trunc = trunctol(atol = collect(S)[1] / 2)
+            trunc = trunctol(atol = maximum(S) / 2)
             alg_trunc = TruncatedAlgorithm(alg, trunc)
 
             USVᴴ, USVᴴtrunc, ΔUSVᴴ_arrays, ΔUSVᴴtrunc_arrays = ad_svd_trunc_setup(A, alg_trunc)

--- a/test/testsuite/mooncake/svd.jl
+++ b/test/testsuite/mooncake/svd.jl
@@ -141,7 +141,7 @@ function test_mooncake_svd_trunc(
 
         @testset "trunctol" begin
             S = svd_vals(A)
-            trunc = trunctol(atol = S[1] / 2)
+            trunc = trunctol(atol = collect(S)[1] / 2)
             alg_trunc = TruncatedAlgorithm(alg, trunc)
 
             USVᴴ, USVᴴtrunc, ΔUSVᴴ_arrays, ΔUSVᴴtrunc_arrays = ad_svd_trunc_setup(A, alg_trunc)


### PR DESCRIPTION
Should fix https://github.com/QuantumKitHub/MatrixAlgebraKit.jl/issues/228

We need to `collect` the `ind`s for the truncated tests because otherwise we trigger scalar indexing :(

The solution for the pullback itself is a bit rough so if someone has a nicer list comprehension, feel free to suggest!