### PR TITLE
Release v0.6.8

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MatrixAlgebraKit"
 uuid = "6c742aac-3347-4629-af66-fc926824e5e4"
-version = "0.6.7"
+version = "0.6.8"
 authors = ["Jutho Haegeman <jutho.haegeman@ugent.be>, Lukas Devos, Katharine Hyatt and contributors"]
 
 [deps]

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -18,7 +18,7 @@ When making changes to this project, please update the "Unreleased" section with
 
 When releasing a new version, move the "Unreleased" changes to a new version section with the release date.
 
-## [Unreleased](https://github.com/QuantumKitHub/MatrixAlgebraKit.jl/compare/v0.6.7...HEAD)
+## [Unreleased](https://github.com/QuantumKitHub/MatrixAlgebraKit.jl/compare/v0.6.8...HEAD)
 
 ### Added
 
@@ -30,9 +30,30 @@ When releasing a new version, move the "Unreleased" changes to a new version sec
 
 ### Fixed
 
+### Performance
+
+## [0.6.8](https://github.com/QuantumKitHub/MatrixAlgebraKit.jl/compare/v0.6.7...v0.6.8) - 2026-05-20
+
+### Added
+
+- Add a MatrixAlgebraKit logo ([#230](https://github.com/QuantumKitHub/MatrixAlgebraKit.jl/pull/230)).
+
+### Changed
+
+- Extended AD test coverage to CUDA arrays for the polar decomposition ([#237](https://github.com/QuantumKitHub/MatrixAlgebraKit.jl/pull/237)) and the Mooncake projection rules ([#240](https://github.com/QuantumKitHub/MatrixAlgebraKit.jl/pull/240)).
+
+### Fixed
+
 - Pullbacks of `eig_trunc`, `eigh_trunc`, and `svd_trunc` no longer error when the truncation strategy keeps no values; `svd_pullback!` also handles the zero-rank case where every singular value falls below `rank_atol` ([#233](https://github.com/QuantumKitHub/MatrixAlgebraKit.jl/pull/233)).
+- `svd_pullback!` is now GPU-compatible ([#232](https://github.com/QuantumKitHub/MatrixAlgebraKit.jl/pull/232)).
+- LQ pullback no longer modifies input cotangents ([#226](https://github.com/QuantumKitHub/MatrixAlgebraKit.jl/pull/226)).
+- `eigh` pullback now works on CUDA arrays ([#235](https://github.com/QuantumKitHub/MatrixAlgebraKit.jl/pull/235)).
+- `eig` pullback now works on CUDA arrays ([#236](https://github.com/QuantumKitHub/MatrixAlgebraKit.jl/pull/236)).
+- Corrected the Enzyme rule's check for when the cached output argument must be copied ([#239](https://github.com/QuantumKitHub/MatrixAlgebraKit.jl/pull/239)).
 
 ### Performance
+
+- Improved `svd` gauge-fixing performance ([#238](https://github.com/QuantumKitHub/MatrixAlgebraKit.jl/pull/238)).
 
 ## [0.6.7](https://github.com/QuantumKitHub/MatrixAlgebraKit.jl/compare/v0.6.6...v0.6.7) - 2026-05-06
 


### PR DESCRIPTION
## MatrixAlgebraKit.jl v0.6.8

Bug-fix release addressing several pullback issues — GPU compatibility for `svd_pullback!`, `eigh`, and `eig` pullbacks, correct handling of fully truncated decompositions, a cotangent-mutation bug in the LQ pullback, and an Enzyme caching fix — plus an `svd` gauge-fixing performance improvement and a new project logo. (Shout-out to @VictorVanthilt)

### Highlights
- `svd_pullback!` now works on the GPU ([#232](https://github.com/QuantumKitHub/MatrixAlgebraKit.jl/pull/232)).
- `eigh` and `eig` pullbacks now work on CUDA arrays ([#235](https://github.com/QuantumKitHub/MatrixAlgebraKit.jl/pull/235), [#236](https://github.com/QuantumKitHub/MatrixAlgebraKit.jl/pull/236)).
- Pullbacks of `eig_trunc`, `eigh_trunc`, and `svd_trunc` no longer error when truncation keeps no values; the zero-rank case in `svd_pullback!` is also handled ([#233](https://github.com/QuantumKitHub/MatrixAlgebraKit.jl/pull/233)).
- LQ pullback no longer mutates the input cotangents ([#226](https://github.com/QuantumKitHub/MatrixAlgebraKit.jl/pull/226)).
- Corrected the Enzyme rule's check for when the cached output argument must be copied ([#239](https://github.com/QuantumKitHub/MatrixAlgebraKit.jl/pull/239)).
- Improved `svd` gauge-fixing performance ([#238](https://github.com/QuantumKitHub/MatrixAlgebraKit.jl/pull/238)).
- Extended AD test coverage to CUDA arrays for the polar decomposition and Mooncake projection rules ([#237](https://github.com/QuantumKitHub/MatrixAlgebraKit.jl/pull/237), [#240](https://github.com/QuantumKitHub/MatrixAlgebraKit.jl/pull/240)).
- New MatrixAlgebraKit logo ([#230](https://github.com/QuantumKitHub/MatrixAlgebraKit.jl/pull/230)).

### Full Changelog
See [CHANGELOG](https://github.com/QuantumKitHub/MatrixAlgebraKit.jl/blob/main/docs/src/changelog.md#068---2026-05-20) for the complete list of changes.
