### PR TITLE
Test polar AD for CUDA

### DIFF
--- a/test/mooncake/polar.jl
+++ b/test/mooncake/polar.jl
@@ -19,8 +19,17 @@ for T in (BLASFloats..., GenericFloats...), n in (17, m, 23)
         n >= m && TestSuite.test_mooncake_right_polar(T, (m, n); atol, rtol)
         #=if m == n
             AT = Diagonal{T, Vector{T}}
-            TestSuite.test_mooncake_left_polar(AT, m; atol = m * n * TestSuite.precision(T), rtol = m * n * TestSuite.precision(T))
-            TestSuite.test_mooncake_right_polar(AT, m; atol = m * n * TestSuite.precision(T), rtol = m * n * TestSuite.precision(T))
-        end=# # broken due to pullback
+            TestSuite.test_mooncake_left_polar(AT, m; atol, rtol)
+            TestSuite.test_mooncake_right_polar(AT, m; atol, rtol)
+        end=#
+    end
+    if T ∈ BLASFloats && CUDA.functional()
+        m >= n && TestSuite.test_mooncake_left_polar(CuMatrix{T}, (m, n); atol, rtol)
+        n >= m && TestSuite.test_mooncake_right_polar(CuMatrix{T}, (m, n); atol, rtol)
+        #=if m == n
+            AT = Diagonal{T, CuVector{T}}
+            TestSuite.test_mooncake_left_polar(AT, m; atol, rtol)
+            TestSuite.test_mooncake_right_polar(AT, m; atol, rtol)
+        end=#
     end
 end

--- a/test/mooncake/polar.jl
+++ b/test/mooncake/polar.jl
@@ -13,8 +13,8 @@ is_buildkite = get(ENV, "BUILDKITE", "false") == "true"
 m = 19
 for T in (BLASFloats..., GenericFloats...), n in (17, m, 23)
     TestSuite.seed_rng!(1234)
+    atol = rtol = m * n * TestSuite.precision(T)
     if !is_buildkite
-        atol = rtol = m * n * TestSuite.precision(T)
         m >= n && TestSuite.test_mooncake_left_polar(T, (m, n); atol, rtol)
         n >= m && TestSuite.test_mooncake_right_polar(T, (m, n); atol, rtol)
         #=if m == n


### PR DESCRIPTION
The `Diagonal` case is already not working for CPU side arrays so I didn't stress too much about it. Happily the CUDA one for full matrices "just works".