### PR TITLE
Improve svd gaugefixing performance

### DIFF
--- a/src/common/gauge.jl
+++ b/src/common/gauge.jl
@@ -67,9 +67,9 @@ end
 
 function gaugefix!(::Union{typeof(svd_compact!), typeof(svd_trunc!)}, U, Vᴴ)
     @assert axes(U, 2) == axes(Vᴴ, 1)
-    signs = sign.(reduce(_largest, U; dims = 1, init = zero(eltype(U))))
-    signs_t = transpose(signs)
-    @. U = U * conj(signs)
-    @. Vᴴ = signs_t * Vᴴ
+    max_us = reduce(_largest, U; dims = 1, init = zero(eltype(U)))
+    max_us_t = transpose(max_us)
+    @. U = U * (conj ∘ sign)(max_us)
+    @. Vᴴ = sign(max_us_t) * Vᴴ
     return (U, Vᴴ)
 end

--- a/src/common/gauge.jl
+++ b/src/common/gauge.jl
@@ -67,9 +67,10 @@ end
 
 function gaugefix!(::Union{typeof(svd_compact!), typeof(svd_trunc!)}, U, Vᴴ)
     @assert axes(U, 2) == axes(Vᴴ, 1)
-    max_us = reduce(_largest, U; dims = 1, init = zero(eltype(U)))
-    max_us_t = transpose(max_us)
-    @. U = U * (conj ∘ sign)(max_us)
-    @. Vᴴ = sign(max_us_t) * Vᴴ
+    signs = reduce(_largest, U; dims = 1, init = zero(eltype(U)))
+    @. signs = sign(signs)
+    signs_t = transpose(signs)
+    @. U = U * conj(signs)
+    @. Vᴴ = signs_t * Vᴴ
     return (U, Vᴴ)
 end

--- a/src/common/gauge.jl
+++ b/src/common/gauge.jl
@@ -10,7 +10,8 @@ is real and positive.
 
 # Helper functions
 _argmaxabs(x) = reduce(_largest, x; init = zero(eltype(x)))
-_largest(x, y) = abs(x) < abs(y) ? y : x
+_largest(x::Real, y::Real) = abs(x) < abs(y) ? y : x
+_largest(x::Complex, y::Complex) = abs2(x) < abs2(y) ? y : x
 
 function gaugefix!(::typeof(qr_householder!), Q, R, Rd)
     ax = Base.OneTo(length(Rd))

--- a/src/common/gauge.jl
+++ b/src/common/gauge.jl
@@ -10,7 +10,7 @@ is real and positive.
 
 # Helper functions
 _argmaxabs(x) = reduce(_largest, x; init = zero(eltype(x)))
-_largest(x, y) = abs(x) < abs(y) ? y : x
+_largest(x, y) = real(abs(x)) < real(abs(y)) ? y : x
 
 function gaugefix!(::typeof(qr_householder!), Q, R, Rd)
     ax = Base.OneTo(length(Rd))
@@ -67,12 +67,8 @@ end
 
 function gaugefix!(::Union{typeof(svd_compact!), typeof(svd_trunc!)}, U, Vᴴ)
     @assert axes(U, 2) == axes(Vᴴ, 1)
-    for j in axes(U, 2)
-        u = view(U, :, j)
-        v = view(Vᴴ, j, :)
-        s = sign(_argmaxabs(u))
-        u .*= conj(s)
-        v .*= s
-    end
+    signs = sign.(reduce(_largest, U; dims = 1, init = zero(eltype(U))))
+    @. U = U * signs
+    @. transpose(Vᴴ) = signs * transpose(Vᴴ)
     return (U, Vᴴ)
 end

--- a/src/common/gauge.jl
+++ b/src/common/gauge.jl
@@ -10,7 +10,7 @@ is real and positive.
 
 # Helper functions
 _argmaxabs(x) = reduce(_largest, x; init = zero(eltype(x)))
-_largest(x, y) = real(abs(x)) < real(abs(y)) ? y : x
+_largest(x, y) = abs(x) < abs(y) ? y : x
 
 function gaugefix!(::typeof(qr_householder!), Q, R, Rd)
     ax = Base.OneTo(length(Rd))
@@ -68,7 +68,8 @@ end
 function gaugefix!(::Union{typeof(svd_compact!), typeof(svd_trunc!)}, U, Vᴴ)
     @assert axes(U, 2) == axes(Vᴴ, 1)
     signs = sign.(reduce(_largest, U; dims = 1, init = zero(eltype(U))))
-    @. U = U * signs
-    @. transpose(Vᴴ) = signs * transpose(Vᴴ)
+    signs_t = transpose(signs)
+    @. U = U * conj(signs)
+    @. Vᴴ = signs_t * Vᴴ
     return (U, Vᴴ)
 end


### PR DESCRIPTION
The existing function is extremely inefficient on GPU as it performs a **separate** `reduce` for every column of `U`. Here, these are combined into one `mapreducedim` call under the hood. This also allows us to avoid a lot of separate kernel launches by updating `U` and `Vh` in one broadcast call each, rather than separate calls for each column/row.

Some testing with `@btime` for `size(U) = (64,32)` and `size(Vh) = (32,128)` showed:

```
Old:  3.093 ms (3976 allocations: 132.08 KiB)
New:  66.295 μs (120 allocations: 4.38 KiB)
```

So a pretty substantial improvement. And 

```julia
U1 = copy(U)                                                                                                                                                                                                    
U2 = copy(U)                                                                                                                                                                                                    
Vᴴ1 = copy(Vᴴ)                                                                                                                                                                                                  
Vᴴ2 = copy(Vᴴ)                                                                                                                                                                                                  
                                                                                                                                                                                                                
@assert collect(gaugefix_old!(U1, Vᴴ1)) ≈ collect(gaugefix_new!(U2, Vᴴ2))    
```
passed! (Although let me check this again with `randn`...)