### PR TITLE
restrict type exponential

### DIFF
--- a/src/implementations/exponential.jl
+++ b/src/implementations/exponential.jl
@@ -55,7 +55,7 @@ function exponential!(A::AbstractMatrix, expA::AbstractMatrix, alg::MatrixFuncti
     return expA
 end
 
-exponential!(A, expA, alg::MatrixFunctionViaEigh) = exponential!((one(eltype(A)), A), expA, alg)
+exponential!(A::AbstractMatrix, expA::AbstractMatrix, alg::MatrixFunctionViaEigh) = exponential!((one(eltype(A)), A), expA, alg)
 exponential!(A::AbstractMatrix, expA::AbstractMatrix, alg::MatrixFunctionViaEig) = exponential!((one(eltype(A)), A), expA, alg)
 
 function exponential!((τ, A)::Tuple{Number, AbstractMatrix}, expA::AbstractMatrix, alg::AbstractAlgorithm)


### PR DESCRIPTION
I came across this small inconsistency when testing `exponential` for TensorKit. If we don't restrict this for `eigh` (like we already did for `eig`), there is some ambiguity later on. 