### PR TITLE
fix: `exponential` method ambiguity resolutions

### DIFF
--- a/src/implementations/exponential.jl
+++ b/src/implementations/exponential.jl
@@ -44,8 +44,8 @@ end
 # ---------------------------
 exponential!(A::AbstractMatrix, alg::DefaultAlgorithm) = exponential!(A, select_algorithm(exponential!, A, nothing; alg.kwargs...))
 exponential!(A::AbstractMatrix, out, alg::DefaultAlgorithm) = exponential!(A, out, select_algorithm(exponential!, A, nothing; alg.kwargs...))
-exponential!((τ, A)::Tuple{Number, AbstractMatrix}, alg::DefaultAlgorithm) = exponential!(A, select_algorithm(exponential!, A, nothing; alg.kwargs...))
-exponential!((τ, A)::Tuple{Number, AbstractMatrix}, out, alg::DefaultAlgorithm) = exponential!(A, out, select_algorithm(exponential!, A, nothing; alg.kwargs...))
+exponential!(τA::Tuple{Number, AbstractMatrix}, alg::DefaultAlgorithm) = exponential!(τA, select_algorithm(exponential!, τA, nothing; alg.kwargs...))
+exponential!(τA::Tuple{Number, AbstractMatrix}, out, alg::DefaultAlgorithm) = exponential!(τA, out, select_algorithm(exponential!, τA, nothing; alg.kwargs...))
 
 # Outputs
 # -------

--- a/src/implementations/exponential.jl
+++ b/src/implementations/exponential.jl
@@ -8,14 +8,14 @@ copy_input(::typeof(exponential), A::Diagonal) = copy(A)
 copy_input(::typeof(exponential), (τ, A)::Tuple{Number, AbstractMatrix}) = (τ, copy!(similar(A, float(eltype(A))), A))
 copy_input(::typeof(exponential), (τ, A)::Tuple{Number, Diagonal}) = τ, copy(A)
 
-function check_input(::typeof(exponential!), A::AbstractMatrix, expA::AbstractMatrix, alg::AbstractAlgorithm)
+function check_input(::typeof(exponential!), A::AbstractMatrix, expA, alg::AbstractAlgorithm)
     m = LinearAlgebra.checksquare(A)
     @check_size(expA, (m, m))
     @check_scalar(expA, A)
     return nothing
 end
 
-function check_input(::typeof(exponential!), A::AbstractMatrix, expA::AbstractMatrix, ::DiagonalAlgorithm)
+function check_input(::typeof(exponential!), A::AbstractMatrix, expA, ::DiagonalAlgorithm)
     m = LinearAlgebra.checksquare(A)
     @assert isdiag(A)
     @assert expA isa Diagonal
@@ -24,14 +24,14 @@ function check_input(::typeof(exponential!), A::AbstractMatrix, expA::AbstractMa
     return nothing
 end
 
-function check_input(::typeof(exponential!), (τ, A)::Tuple{Number, AbstractMatrix}, expA::AbstractMatrix, alg::AbstractAlgorithm)
+function check_input(::typeof(exponential!), (τ, A)::Tuple{Number, AbstractMatrix}, expA, alg::AbstractAlgorithm)
     m = LinearAlgebra.checksquare(A)
     @check_size(expA, (m, m))
     @check_scalar(expA, A, (τ isa Real) ? identity : complex)
     return nothing
 end
 
-function check_input(::typeof(exponential!), (τ, A)::Tuple{Number, AbstractMatrix}, expA::AbstractMatrix, ::DiagonalAlgorithm)
+function check_input(::typeof(exponential!), (τ, A)::Tuple{Number, AbstractMatrix}, expA, ::DiagonalAlgorithm)
     m = LinearAlgebra.checksquare(A)
     @assert isdiag(A)
     @assert expA isa Diagonal
@@ -43,9 +43,9 @@ end
 # Algorithm selection
 # ---------------------------
 exponential!(A::AbstractMatrix, alg::DefaultAlgorithm) = exponential!(A, select_algorithm(exponential!, A, nothing; alg.kwargs...))
-exponential!(A::AbstractMatrix, out::AbstractMatrix, alg::DefaultAlgorithm) = exponential!(A, out, select_algorithm(exponential!, A, nothing; alg.kwargs...))
+exponential!(A::AbstractMatrix, out, alg::DefaultAlgorithm) = exponential!(A, out, select_algorithm(exponential!, A, nothing; alg.kwargs...))
 exponential!(τA::Tuple{Number, AbstractMatrix}, alg::DefaultAlgorithm) = exponential!(τA, select_algorithm(exponential!, τA, nothing; alg.kwargs...))
-exponential!(τA::Tuple{Number, AbstractMatrix}, out::AbstractMatrix, alg::DefaultAlgorithm) = exponential!(τA, out, select_algorithm(exponential!, τA, nothing; alg.kwargs...))
+exponential!(τA::Tuple{Number, AbstractMatrix}, out, alg::DefaultAlgorithm) = exponential!(τA, out, select_algorithm(exponential!, τA, nothing; alg.kwargs...))
 
 # Outputs
 # -------
@@ -55,22 +55,22 @@ initialize_output(::typeof(exponential!), (τ, A)::Tuple{Number, AbstractMatrix}
 
 # Implementation
 # --------------
-function exponential!(A::AbstractMatrix, expA::AbstractMatrix, alg::MatrixFunctionViaLA)
+function exponential!(A::AbstractMatrix, expA, alg::MatrixFunctionViaLA)
     check_input(exponential!, A, expA, alg)
     A = LinearAlgebra.exp!(A)
     A === expA || copy!(expA, A)
     return expA
 end
 
-exponential!(A::AbstractMatrix, expA::AbstractMatrix, alg::MatrixFunctionViaEigh) = exponential!((one(eltype(A)), A), expA, alg)
-exponential!(A::AbstractMatrix, expA::AbstractMatrix, alg::MatrixFunctionViaEig) = exponential!((one(eltype(A)), A), expA, alg)
+exponential!(A::AbstractMatrix, expA, alg::MatrixFunctionViaEigh) = exponential!((one(eltype(A)), A), expA, alg)
+exponential!(A::AbstractMatrix, expA, alg::MatrixFunctionViaEig) = exponential!((one(eltype(A)), A), expA, alg)
 
-function exponential!((τ, A)::Tuple{Number, AbstractMatrix}, expA::AbstractMatrix, alg::AbstractAlgorithm)
+function exponential!((τ, A)::Tuple{Number, AbstractMatrix}, expA, alg::AbstractAlgorithm)
     expA .= A .* τ
     return exponential!(expA, expA, alg)
 end
 
-function exponential!((τ, A)::Tuple{Number, AbstractMatrix}, expA::AbstractMatrix, alg::MatrixFunctionViaEigh)
+function exponential!((τ, A)::Tuple{Number, AbstractMatrix}, expA, alg::MatrixFunctionViaEigh)
     check_input(exponential!, (τ, A), expA, alg)
     D, V = eigh_full!(A, alg.eigh_alg)
     if eltype(A) <: Real
@@ -90,7 +90,7 @@ function exponential!((τ, A)::Tuple{Number, AbstractMatrix}, expA::AbstractMatr
     end
 end
 
-function exponential!((τ, A)::Tuple{Number, AbstractMatrix}, expA::AbstractMatrix, alg::MatrixFunctionViaEig)
+function exponential!((τ, A)::Tuple{Number, AbstractMatrix}, expA, alg::MatrixFunctionViaEig)
     check_input(exponential!, (τ, A), expA, alg)
     D, V = eig_full!(A, alg.eig_alg)
     if eltype(A) <: Real && eltype(τ) <: Real
@@ -105,12 +105,12 @@ end
 
 # Diagonal logic
 # --------------
-function exponential!(A::AbstractMatrix, expA::AbstractMatrix, alg::DiagonalAlgorithm)
+function exponential!(A::AbstractMatrix, expA, alg::DiagonalAlgorithm)
     check_input(exponential!, A, expA, alg)
     return map_diagonal!(exp, expA, A)
 end
 
-function exponential!((τ, A)::Tuple{Number, AbstractMatrix}, expA::AbstractMatrix, alg::DiagonalAlgorithm)
+function exponential!((τ, A)::Tuple{Number, AbstractMatrix}, expA, alg::DiagonalAlgorithm)
     check_input(exponential!, (τ, A), expA, alg)
     return map_diagonal!(x -> exp(x * τ), expA, A)
 end

--- a/src/implementations/exponential.jl
+++ b/src/implementations/exponential.jl
@@ -43,9 +43,9 @@ end
 # Algorithm selection
 # ---------------------------
 exponential!(A::AbstractMatrix, alg::DefaultAlgorithm) = exponential!(A, select_algorithm(exponential!, A, nothing; alg.kwargs...))
-exponential!(A::AbstractMatrix, out, alg::DefaultAlgorithm) = exponential!(A, out, select_algorithm(exponential!, A, nothing; alg.kwargs...))
+exponential!(A::AbstractMatrix, out::AbstractMatrix, alg::DefaultAlgorithm) = exponential!(A, out, select_algorithm(exponential!, A, nothing; alg.kwargs...))
 exponential!(τA::Tuple{Number, AbstractMatrix}, alg::DefaultAlgorithm) = exponential!(τA, select_algorithm(exponential!, τA, nothing; alg.kwargs...))
-exponential!(τA::Tuple{Number, AbstractMatrix}, out, alg::DefaultAlgorithm) = exponential!(τA, out, select_algorithm(exponential!, τA, nothing; alg.kwargs...))
+exponential!(τA::Tuple{Number, AbstractMatrix}, out::AbstractMatrix, alg::DefaultAlgorithm) = exponential!(τA, out, select_algorithm(exponential!, τA, nothing; alg.kwargs...))
 
 # Outputs
 # -------

--- a/src/implementations/exponential.jl
+++ b/src/implementations/exponential.jl
@@ -43,9 +43,9 @@ end
 # Algorithm selection
 # ---------------------------
 exponential!(A::AbstractMatrix, alg::DefaultAlgorithm) = exponential!(A, select_algorithm(exponential!, A, nothing; alg.kwargs...))
-exponential!(A::AbstractMatrix, out, alg::DefaultAlgorithm) = exponential!(A, out, select_algorithm(exponential!, A, nothing; alg.kwargs...))
+exponential!(A::AbstractMatrix, out::AbstractMatrix, alg::DefaultAlgorithm) = exponential!(A, out, select_algorithm(exponential!, A, nothing; alg.kwargs...))
 exponential!((τ, A)::Tuple{Number, AbstractMatrix}, alg::DefaultAlgorithm) = exponential!(A, select_algorithm(exponential!, A, nothing; alg.kwargs...))
-exponential!((τ, A)::Tuple{Number, AbstractMatrix}, out, alg::DefaultAlgorithm) = exponential!(A, out, select_algorithm(exponential!, A, nothing; alg.kwargs...))
+exponential!((τ, A)::Tuple{Number, AbstractMatrix}, out::AbstractMatrix, alg::DefaultAlgorithm) = exponential!(A, out, select_algorithm(exponential!, A, nothing; alg.kwargs...))
 
 # Outputs
 # -------

--- a/src/implementations/exponential.jl
+++ b/src/implementations/exponential.jl
@@ -40,6 +40,12 @@ function check_input(::typeof(exponential!), (τ, A)::Tuple{Number, AbstractMatr
     return nothing
 end
 
+# DefaultAlgorithm intercepts
+# ---------------------------
+
+exponential!(t::Tuple{E, T}, ::DefaultAlgorithm) where {E <: Number, T <: Diagonal} = MAK.exponential!(t, DiagonalAlgorithm())
+exponential!(t::Tuple{E, T1}, out::T2, ::DefaultAlgorithm) where {E <: Number, T1 <: Diagonal, T2 <: Diagonal} = MAK.exponential!(t, out, DiagonalAlgorithm())
+
 # Outputs
 # -------
 initialize_output(::typeof(exponential!), A::AbstractMatrix, ::AbstractAlgorithm) = A

--- a/src/implementations/exponential.jl
+++ b/src/implementations/exponential.jl
@@ -40,11 +40,12 @@ function check_input(::typeof(exponential!), (τ, A)::Tuple{Number, AbstractMatr
     return nothing
 end
 
-# DefaultAlgorithm intercepts
+# Algorithm selection
 # ---------------------------
-
-exponential!(t::Tuple{E, T}, ::DefaultAlgorithm) where {E <: Number, T <: Diagonal} = MAK.exponential!(t, DiagonalAlgorithm())
-exponential!(t::Tuple{E, T1}, out::T2, ::DefaultAlgorithm) where {E <: Number, T1 <: Diagonal, T2 <: Diagonal} = MAK.exponential!(t, out, DiagonalAlgorithm())
+exponential!(A::AbstractMatrix, alg::DefaultAlgorithm) = exponential!(A, select_algorithm(exponential!, A, nothing; alg.kwargs...))
+exponential!(A::AbstractMatrix, out, alg::DefaultAlgorithm) = exponential!(A, out, select_algorithm(exponential!, A, nothing; alg.kwargs...))
+exponential!((τ, A)::Tuple{Number, AbstractMatrix}, alg::DefaultAlgorithm) = exponential!(A, select_algorithm(exponential!, A, nothing; alg.kwargs...))
+exponential!((τ, A)::Tuple{Number, AbstractMatrix}, out, alg::DefaultAlgorithm) = exponential!(A, out, select_algorithm(exponential!, A, nothing; alg.kwargs...))
 
 # Outputs
 # -------

--- a/src/implementations/exponential.jl
+++ b/src/implementations/exponential.jl
@@ -98,7 +98,7 @@ end
 
 # Diagonal logic
 # --------------
-function exponential!(A, expA, alg::DiagonalAlgorithm)
+function exponential!(A::AbstractMatrix, expA::AbstractMatrix, alg::DiagonalAlgorithm)
     check_input(exponential!, A, expA, alg)
     return map_diagonal!(exp, expA, A)
 end

--- a/src/interface/exponential.jl
+++ b/src/interface/exponential.jl
@@ -35,5 +35,9 @@ function default_algorithm(::typeof(exponential!), ::Type{A}; kwargs...) where {
 end
 
 function default_algorithm(::typeof(exponential!), ::Tuple{A, B}; kwargs...) where {A, B}
-    return default_exponential_algorithm(B; kwargs...)
+    return default_algorithm(exponential!, B; kwargs...)
+end
+
+function default_algorithm(::typeof(exponential!), ::Type{Tuple{A, B}}; kwargs...) where {A, B}
+    return default_algorithm(exponential!, B; kwargs...)
 end


### PR DESCRIPTION
This is another type restriction (see #252) to make sure the exponential in TensorKit will be implemented correctly (see QuantumKitHub/TensorKit.jl#465). If I don't restrict these types, it will be ambiguous with this function in TensorKit (src/factorizations/matrixalgebrakit.jl).

```julia
for f! in (
        :qr_null!, :lq_null!,
        :svd_vals!, :eig_vals!, :eigh_vals!,
        :project_hermitian!, :project_antihermitian!, :project_isometric!,
        :exponential!,
    )
    @eval function MAK.$f!(t::AbstractTensorMap, N, alg::AbstractAlgorithm)
        $(f! in (:eig_vals!, :eigh_vals!, :project_hermitian!, :project_antihermitian!) && :(LinearAlgebra.checksquare(t)))
        foreachblock(t, N) do _, (tblock, Nblock)
            Nblock′ = $f!(tblock, Nblock, alg)
            # deal with the case where the output is not the same as the input
            Nblock === Nblock′ || copy!(Nblock, Nblock′)
            return nothing
        end
        return N
    end
end
```