### PR TITLE
Instantiate broadcast for pullbacks

### DIFF
--- a/src/pullbacks/eig.jl
+++ b/src/pullbacks/eig.jl
@@ -30,7 +30,7 @@ function check_and_prepare_eig_cotangents(
     bc = Base.broadcasted(transpose(D), D, VᴴΔV₁) do d₁, d₂, v
         return abs(d₁ - d₂) < degeneracy_atol ? v : zero(v)
     end
-    Δgauge = maximum(abs, bc; init = abs(zero(eltype(D))))
+    Δgauge = maximum(abs, Base.Broadcast.instantiate(bc); init = abs(zero(eltype(D))))
 
     Δgauge ≤ gauge_atol ||
         @warn "`eig` cotangents sensitive to gauge choice: (|Δgauge| = $Δgauge)"

--- a/src/pullbacks/eigh.jl
+++ b/src/pullbacks/eigh.jl
@@ -31,7 +31,7 @@ function check_and_prepare_eigh_cotangents(
     bc = Base.broadcasted(transpose(D), D, aVᴴΔV₁) do d₁, d₂, v
         return abs(d₁ - d₂) < degeneracy_atol ? v : zero(v)
     end
-    Δgauge = maximum(abs, bc; init = abs(zero(eltype(D))))
+    Δgauge = maximum(abs, Base.Broadcast.instantiate(bc); init = abs(zero(eltype(D))))
 
     Δgauge ≤ gauge_atol ||
         @warn "`eigh` cotangents sensitive to gauge choice: (|Δgauge| = $Δgauge)"

--- a/src/pullbacks/svd.jl
+++ b/src/pullbacks/svd.jl
@@ -85,7 +85,7 @@ function check_and_prepare_svd_cotangents(
     bc = Base.broadcasted(S₁', S₁, aUᴴΔU₁, aVᴴΔV₁) do s₁, s₂, u, v
         return abs(s₁ - s₂) < degeneracy_atol ? u + v : zero(u) + zero(v)
     end
-    Δgauge = max(Δgauge, maximum(abs, bc))
+    Δgauge = max(Δgauge, maximum(abs, Base.Broadcast.instantiate(bc)))
 
     if !iszerotangent(ΔSmat)
         ΔS = diagview(ΔSmat)


### PR DESCRIPTION
This prevents an `axes` check from exploding further up the stack when PEPSKit tries to call this